### PR TITLE
Wire BOOT_COMPLETED receiver to AUTO_START preference

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:name=".AirPlayApp"
@@ -37,6 +38,16 @@
             android:name=".service.AirPlayService"
             android:foregroundServiceType="connectedDevice|mediaPlayback"
             android:exported="false" />
+
+        <receiver
+            android:name=".BootReceiver"
+            android:enabled="true"
+            android:exported="true"
+            android:permission="android.permission.RECEIVE_BOOT_COMPLETED">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/kotlin/io/github/jqssun/airplay/BootReceiver.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/BootReceiver.kt
@@ -1,0 +1,17 @@
+package io.github.jqssun.airplay
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.ContextCompat
+import io.github.jqssun.airplay.service.AirPlayService
+
+class BootReceiver : BroadcastReceiver() {
+    override fun onReceive(ctx: Context, intent: Intent) {
+        if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
+        val prefs = ctx.getSharedPreferences(Prefs.NAME, Context.MODE_PRIVATE)
+        if (!prefs.getBoolean(Prefs.AUTO_START, Prefs.DEF_AUTO_START)) return
+        val svcIntent = Intent(ctx, AirPlayService::class.java).setAction(AirPlayService.ACTION_AUTO_START)
+        ContextCompat.startForegroundService(ctx, svcIntent)
+    }
+}

--- a/app/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
@@ -132,7 +132,14 @@ class AirPlayService : Service(), RaopCallbackHandler {
         ContextCompat.registerReceiver(this, mediaReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
     }
 
-    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int = START_NOT_STICKY
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent?.action == ACTION_AUTO_START && _serverState.value != ServerState.RUNNING) {
+            val prefs = getSharedPreferences(Prefs.NAME, Context.MODE_PRIVATE)
+            val name = prefs.getString(Prefs.SERVER_NAME, Prefs.DEF_SERVER_NAME) ?: Prefs.DEF_SERVER_NAME
+            startServer(name)
+        }
+        return START_NOT_STICKY
+    }
 
     fun startServer(name: String) {
         if (_serverState.value == ServerState.RUNNING) return
@@ -521,5 +528,6 @@ class AirPlayService : Service(), RaopCallbackHandler {
         const val ACTION_PLAY_PAUSE = "io.github.jqssun.airplay.PLAY_PAUSE"
         const val ACTION_NEXT = "io.github.jqssun.airplay.NEXT"
         const val ACTION_PREV = "io.github.jqssun.airplay.PREV"
+        const val ACTION_AUTO_START = "io.github.jqssun.airplay.AUTO_START"
     }
 }


### PR DESCRIPTION
The AUTO_START pref existed in settings but had no effect after reboot. Adds a BootReceiver that starts the foreground service if the pref is enabled, reading the saved server name.