### PR TITLE
Bring UI to foreground when client connects

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,7 +36,7 @@ android {
         versionName = "0.0.7"
 
         ndk {
-            abiFilters += listOf("arm64-v8a", "x86_64")
+            abiFilters += listOf("arm64-v8a", "armeabi-v7a", "x86_64")
         }
 
         externalNativeBuild {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,10 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+
+    <uses-feature android:name="android.software.leanback" android:required="false" />
+    <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
 
     <application
         android:name=".AirPlayApp"
@@ -17,6 +21,7 @@
         android:usesCleartextTraffic="true"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
+        android:banner="@drawable/banner"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.AirPlayServer">
@@ -30,6 +35,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/kotlin/io/github/jqssun/airplay/Prefs.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/Prefs.kt
@@ -21,4 +21,5 @@ object Prefs {
     const val IDLE_PREVIEW = "idle_preview"; const val DEF_IDLE_PREVIEW = false
     const val AUTO_FULLSCREEN = "auto_fullscreen"; const val DEF_AUTO_FULLSCREEN = true
     const val AUTO_AUDIO_MODE = "auto_audio_mode"; const val DEF_AUTO_AUDIO_MODE = true
+    const val LAUNCH_ON_CONNECT = "launch_on_connect"; const val DEF_LAUNCH_ON_CONNECT = true
 }

--- a/app/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
@@ -5,39 +5,40 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.graphics.BitmapFactory
-import android.net.wifi.WifiManager
 import android.os.Binder
+import android.os.Handler
 import android.os.IBinder
+import android.os.Looper
 import android.os.PowerManager
 import android.os.SystemClock
 import android.support.v4.media.MediaMetadataCompat
 import android.support.v4.media.session.MediaSessionCompat
 import android.support.v4.media.session.PlaybackStateCompat
-import androidx.core.app.NotificationCompat
-import androidx.media.app.NotificationCompat as MediaNotificationCompat
-import androidx.core.content.ContextCompat
 import android.util.Log
 import android.view.Surface
-import android.content.BroadcastReceiver
-import android.content.IntentFilter
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+import androidx.media.app.NotificationCompat as MediaNotificationCompat
 import io.github.jqssun.airplay.MainActivity
 import io.github.jqssun.airplay.Prefs
 import io.github.jqssun.airplay.R
 import io.github.jqssun.airplay.audio.DacpController
 import io.github.jqssun.airplay.audio.DmapParser
 import io.github.jqssun.airplay.audio.TrackInfo
-import io.github.jqssun.airplay.viewmodel.DebugInfo
 import io.github.jqssun.airplay.bridge.NativeBridge
 import io.github.jqssun.airplay.bridge.RaopCallbackHandler
 import io.github.jqssun.airplay.discovery.NsdServiceManager
 import io.github.jqssun.airplay.renderer.AudioRenderer
 import io.github.jqssun.airplay.renderer.VideoRenderer
+import io.github.jqssun.airplay.viewmodel.DebugInfo
+import java.net.NetworkInterface
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import java.net.NetworkInterface
 
 class AirPlayService : Service(), RaopCallbackHandler {
 
@@ -84,13 +85,20 @@ class AirPlayService : Service(), RaopCallbackHandler {
         return (_progressBaseMs + elapsed).coerceIn(0, _durationMs.value)
     }
 
-    var dacpController: DacpController? = null; private set
+    var dacpController: DacpController? = null
+        private set
     private var mediaSession: MediaSessionCompat? = null
     private var mediaReceiver: BroadcastReceiver? = null
 
     var logCallback: ((String) -> Unit)? = null
-    var pinCallback: ((String?) -> Unit)? = null
     var modeCallback: ((Boolean) -> Unit)? = null
+
+    @Volatile private var _lastPin: String? = null
+    var pinCallback: ((String?) -> Unit)? = null
+        set(value) {
+            field = value
+            value?.invoke(_lastPin)
+        }
 
     private fun log(msg: String) {
         Log.i(TAG, msg)
@@ -98,7 +106,8 @@ class AirPlayService : Service(), RaopCallbackHandler {
     }
 
     inner class LocalBinder : Binder() {
-        val service: AirPlayService get() = this@AirPlayService
+        val service: AirPlayService
+            get() = this@AirPlayService
     }
 
     override fun onBind(intent: Intent?): IBinder = LocalBinder()
@@ -107,29 +116,49 @@ class AirPlayService : Service(), RaopCallbackHandler {
         super.onCreate()
         createNotificationChannel()
         dacpController = DacpController(this)
-        mediaSession = MediaSessionCompat(this, "AirPlay").apply {
-            setCallback(object : MediaSessionCompat.Callback() {
-                override fun onPlay() { _setPlaying(true); dacpController?.play() }
-                override fun onPause() { _setPlaying(false); dacpController?.pause() }
-                override fun onSkipToNext() { dacpController?.nextItem() }
-                override fun onSkipToPrevious() { dacpController?.prevItem() }
-            })
-        }
-        mediaReceiver = object : BroadcastReceiver() {
-            override fun onReceive(ctx: Context, intent: Intent) {
-                when (intent.action) {
-                    ACTION_PLAY_PAUSE -> togglePlayPause()
-                    ACTION_NEXT -> dacpController?.nextItem()
-                    ACTION_PREV -> dacpController?.prevItem()
+        mediaSession =
+                MediaSessionCompat(this, "AirPlay").apply {
+                    setCallback(
+                            object : MediaSessionCompat.Callback() {
+                                override fun onPlay() {
+                                    _setPlaying(true)
+                                    dacpController?.play()
+                                }
+                                override fun onPause() {
+                                    _setPlaying(false)
+                                    dacpController?.pause()
+                                }
+                                override fun onSkipToNext() {
+                                    dacpController?.nextItem()
+                                }
+                                override fun onSkipToPrevious() {
+                                    dacpController?.prevItem()
+                                }
+                            }
+                    )
                 }
-            }
-        }
-        val filter = IntentFilter().apply {
-            addAction(ACTION_PLAY_PAUSE)
-            addAction(ACTION_NEXT)
-            addAction(ACTION_PREV)
-        }
-        ContextCompat.registerReceiver(this, mediaReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
+        mediaReceiver =
+                object : BroadcastReceiver() {
+                    override fun onReceive(ctx: Context, intent: Intent) {
+                        when (intent.action) {
+                            ACTION_PLAY_PAUSE -> togglePlayPause()
+                            ACTION_NEXT -> dacpController?.nextItem()
+                            ACTION_PREV -> dacpController?.prevItem()
+                        }
+                    }
+                }
+        val filter =
+                IntentFilter().apply {
+                    addAction(ACTION_PLAY_PAUSE)
+                    addAction(ACTION_NEXT)
+                    addAction(ACTION_PREV)
+                }
+        ContextCompat.registerReceiver(
+                this,
+                mediaReceiver,
+                filter,
+                ContextCompat.RECEIVER_NOT_EXPORTED
+        )
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int = START_NOT_STICKY
@@ -140,7 +169,8 @@ class AirPlayService : Service(), RaopCallbackHandler {
 
         val prefs = getSharedPreferences(Prefs.NAME, Context.MODE_PRIVATE)
         val pm = getSystemService(Context.POWER_SERVICE) as PowerManager
-        wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "airplay:server").apply { acquire() }
+        wakeLock =
+                pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "airplay:server").apply { acquire() }
 
         nsdManager = NsdServiceManager(this).apply { acquireMulticastLock() }
 
@@ -164,29 +194,36 @@ class AirPlayService : Service(), RaopCallbackHandler {
         val alac = prefs.getBoolean(Prefs.ALAC_ENABLED, Prefs.DEF_ALAC_ENABLED)
         val aac = prefs.getBoolean(Prefs.AAC_ENABLED, Prefs.DEF_AAC_ENABLED)
 
-        audioRenderer.swAlacEnabled = prefs.getBoolean(Prefs.SW_ALAC_ENABLED, Prefs.DEF_SW_ALAC_ENABLED)
+        audioRenderer.swAlacEnabled =
+                prefs.getBoolean(Prefs.SW_ALAC_ENABLED, Prefs.DEF_SW_ALAC_ENABLED)
         NativeBridge.nativeSetH265Enabled(nativeHandle, h265)
         NativeBridge.nativeSetCodecs(nativeHandle, alac, aac)
         NativeBridge.nativeSetPlist(nativeHandle, "maxFPS", maxFps)
         NativeBridge.nativeSetPlist(nativeHandle, "overscanned", if (overscanned) 1 else 0)
-        if (audioLatencyMs >= 0) NativeBridge.nativeSetPlist(nativeHandle, "audio_delay_micros", audioLatencyMs * 1000)
+        if (audioLatencyMs >= 0)
+                NativeBridge.nativeSetPlist(
+                        nativeHandle,
+                        "audio_delay_micros",
+                        audioLatencyMs * 1000
+                )
 
         // Set display params
         val dm = resources.displayMetrics
         val res = prefs.getString(Prefs.RESOLUTION, Prefs.DEF_RESOLUTION)!!
-        val (w, h) = if (res != "auto" && res.contains("x")) {
-            val parts = res.split("x")
-            parts[0].toInt() to parts[1].toInt()
-        } else {
-            dm.widthPixels to dm.heightPixels
-        }
+        val (w, h) =
+                if (res != "auto" && res.contains("x")) {
+                    val parts = res.split("x")
+                    parts[0].toInt() to parts[1].toInt()
+                } else {
+                    dm.widthPixels to dm.heightPixels
+                }
         videoRenderer.setResolution(w, h)
         _videoResolution.value = "${w}x${h}"
         _videoAspect.value = w.toFloat() / h
         NativeBridge.nativeSetDisplaySize(nativeHandle, w, h, maxFps)
 
-        val requestedPort = prefs.getInt(Prefs.SERVER_PORT, Prefs.DEF_SERVER_PORT)
-            .coerceIn(1, 65535)
+        val requestedPort =
+                prefs.getInt(Prefs.SERVER_PORT, Prefs.DEF_SERVER_PORT).coerceIn(1, 65535)
         val port = NativeBridge.nativeStart(nativeHandle, requestedPort)
         if (port < 0) {
             log("Failed to start on port $requestedPort")
@@ -252,7 +289,11 @@ class AirPlayService : Service(), RaopCallbackHandler {
 
     override fun onDestroy() {
         stopServer()
-        mediaReceiver?.let { try { unregisterReceiver(it) } catch (_: Exception) {} }
+        mediaReceiver?.let {
+            try {
+                unregisterReceiver(it)
+            } catch (_: Exception) {}
+        }
         mediaReceiver = null
         dacpController?.release()
         dacpController = null
@@ -295,11 +336,21 @@ class AirPlayService : Service(), RaopCallbackHandler {
     }
 
     override fun onConnectionInit() {
+        val firstConnection = _connectionCount.value == 0
         _connectionCount.value++
         log("Client connected (${_connectionCount.value})")
-        val launchIntent = Intent(this, MainActivity::class.java)
-            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
-        try { startActivity(launchIntent) } catch (e: Exception) { Log.w(TAG, "UI launch failed", e) }
+        if (!firstConnection) return
+        val prefs = getSharedPreferences(Prefs.NAME, Context.MODE_PRIVATE)
+        if (!prefs.getBoolean(Prefs.LAUNCH_ON_CONNECT, Prefs.DEF_LAUNCH_ON_CONNECT)) return
+        Handler(Looper.getMainLooper()).post {
+            val launchIntent =
+                    Intent(this, MainActivity::class.java)
+                            .addFlags(
+                                    Intent.FLAG_ACTIVITY_NEW_TASK or
+                                            Intent.FLAG_ACTIVITY_REORDER_TO_FRONT
+                            )
+            startActivity(launchIntent)
+        }
     }
 
     override fun onConnectionDestroy() {
@@ -319,6 +370,7 @@ class AirPlayService : Service(), RaopCallbackHandler {
     }
 
     override fun onDisplayPin(pin: String) {
+        _lastPin = pin
         pinCallback?.invoke(pin)
     }
 
@@ -373,14 +425,13 @@ class AirPlayService : Service(), RaopCallbackHandler {
 
     private fun _updateMediaMetadata() {
         val info = _trackInfo.value
-        val builder = MediaMetadataCompat.Builder()
-            .putString(MediaMetadataCompat.METADATA_KEY_TITLE, info.title)
-            .putString(MediaMetadataCompat.METADATA_KEY_ARTIST, info.artist)
-            .putString(MediaMetadataCompat.METADATA_KEY_ALBUM, info.album)
-            .putLong(MediaMetadataCompat.METADATA_KEY_DURATION, _durationMs.value)
-        info.coverArt?.let {
-            builder.putBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART, it)
-        }
+        val builder =
+                MediaMetadataCompat.Builder()
+                        .putString(MediaMetadataCompat.METADATA_KEY_TITLE, info.title)
+                        .putString(MediaMetadataCompat.METADATA_KEY_ARTIST, info.artist)
+                        .putString(MediaMetadataCompat.METADATA_KEY_ALBUM, info.album)
+                        .putLong(MediaMetadataCompat.METADATA_KEY_DURATION, _durationMs.value)
+        info.coverArt?.let { builder.putBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART, it) }
         mediaSession?.setMetadata(builder.build())
         _updateMediaNotification()
     }
@@ -407,36 +458,41 @@ class AirPlayService : Service(), RaopCallbackHandler {
 
     private fun _updatePlaybackState() {
         val isPlaying = _playing.value
-        val pbState = if (isPlaying) PlaybackStateCompat.STATE_PLAYING
-                      else PlaybackStateCompat.STATE_PAUSED
+        val pbState =
+                if (isPlaying) PlaybackStateCompat.STATE_PLAYING
+                else PlaybackStateCompat.STATE_PAUSED
         val speed = if (isPlaying) 1f else 0f
-        val state = PlaybackStateCompat.Builder()
-            .setActions(
-                PlaybackStateCompat.ACTION_PLAY or PlaybackStateCompat.ACTION_PAUSE or
-                PlaybackStateCompat.ACTION_PLAY_PAUSE or
-                PlaybackStateCompat.ACTION_SKIP_TO_NEXT or
-                PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS
-            )
-            .setState(pbState, _positionMs.value, speed, SystemClock.elapsedRealtime())
-            .build()
+        val state =
+                PlaybackStateCompat.Builder()
+                        .setActions(
+                                PlaybackStateCompat.ACTION_PLAY or
+                                        PlaybackStateCompat.ACTION_PAUSE or
+                                        PlaybackStateCompat.ACTION_PLAY_PAUSE or
+                                        PlaybackStateCompat.ACTION_SKIP_TO_NEXT or
+                                        PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS
+                        )
+                        .setState(pbState, _positionMs.value, speed, SystemClock.elapsedRealtime())
+                        .build()
         mediaSession?.setPlaybackState(state)
         _updateMediaNotification()
     }
 
     private fun clearPin() {
+        _lastPin = null
         pinCallback?.invoke(null)
     }
 
-    fun collectDebugInfo() = DebugInfo(
-        videoCodec = videoRenderer.codecName,
-        videoRes = _videoResolution.value,
-        videoFps = videoRenderer.fps,
-        videoBitrate = videoRenderer.bitrateBps,
-        videoFrames = videoRenderer.frameCount,
-        audioCodec = audioRenderer.codecLabel,
-        audioVolume = (audioRenderer.volume * 100).toInt(),
-        connections = _connectionCount.value,
-    )
+    fun collectDebugInfo() =
+            DebugInfo(
+                    videoCodec = videoRenderer.codecName,
+                    videoRes = _videoResolution.value,
+                    videoFps = videoRenderer.fps,
+                    videoBitrate = videoRenderer.bitrateBps,
+                    videoFrames = videoRenderer.frameCount,
+                    audioCodec = audioRenderer.codecLabel,
+                    audioVolume = (audioRenderer.volume * 100).toInt(),
+                    connections = _connectionCount.value,
+            )
 
     // Helpers
 
@@ -452,14 +508,27 @@ class AirPlayService : Service(), RaopCallbackHandler {
         } catch (e: Exception) {
             Log.w(TAG, "Failed to get hardware address", e)
         }
-        // Fallback: random-ish address
-        return byteArrayOf(0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte(), 0xDD.toByte(), 0xEE.toByte(), 0xFF.toByte())
+        // fallback: random-ish address
+        return byteArrayOf(
+                0xAA.toByte(),
+                0xBB.toByte(),
+                0xCC.toByte(),
+                0xDD.toByte(),
+                0xEE.toByte(),
+                0xFF.toByte()
+        )
     }
 
     private fun createNotificationChannel() {
-        val channel = NotificationChannel(CHANNEL_ID, getString(R.string.notification_channel),
-            NotificationManager.IMPORTANCE_LOW)
-        (getSystemService(NOTIFICATION_SERVICE) as NotificationManager).createNotificationChannel(channel)
+        val channel =
+                NotificationChannel(
+                        CHANNEL_ID,
+                        getString(R.string.notification_channel),
+                        NotificationManager.IMPORTANCE_LOW
+                )
+        (getSystemService(NOTIFICATION_SERVICE) as NotificationManager).createNotificationChannel(
+                channel
+        )
     }
 
     private fun buildNotification(): Notification {
@@ -472,41 +541,53 @@ class AirPlayService : Service(), RaopCallbackHandler {
         val info = _trackInfo.value
         val isAudio = _audioOnly.value && info.title.isNotEmpty()
 
-        val builder = NotificationCompat.Builder(this, CHANNEL_ID)
-            .setSmallIcon(android.R.drawable.ic_media_play)
-            .setContentIntent(pi)
-            .setOngoing(true)
+        val builder =
+                NotificationCompat.Builder(this, CHANNEL_ID)
+                        .setSmallIcon(android.R.drawable.ic_media_play)
+                        .setContentIntent(pi)
+                        .setOngoing(true)
 
         if (isAudio) {
-            builder.setContentTitle(info.title)
-                .setContentText(info.artist)
-                .setSubText(info.album)
+            builder.setContentTitle(info.title).setContentText(info.artist).setSubText(info.album)
             info.coverArt?.let { builder.setLargeIcon(it) }
             mediaSession?.sessionToken?.let { token ->
                 builder.setStyle(
-                    MediaNotificationCompat.MediaStyle()
-                        .setMediaSession(token)
-                        .setShowActionsInCompactView(0, 1, 2)
+                        MediaNotificationCompat.MediaStyle()
+                                .setMediaSession(token)
+                                .setShowActionsInCompactView(0, 1, 2)
                 )
                 // Transport action buttons
-                builder.addAction(android.R.drawable.ic_media_previous, "Prev",
-                    _mediaAction(ACTION_PREV))
-                builder.addAction(android.R.drawable.ic_media_pause, "Pause",
-                    _mediaAction(ACTION_PLAY_PAUSE))
-                builder.addAction(android.R.drawable.ic_media_next, "Next",
-                    _mediaAction(ACTION_NEXT))
+                builder.addAction(
+                        android.R.drawable.ic_media_previous,
+                        "Prev",
+                        _mediaAction(ACTION_PREV)
+                )
+                builder.addAction(
+                        android.R.drawable.ic_media_pause,
+                        "Pause",
+                        _mediaAction(ACTION_PLAY_PAUSE)
+                )
+                builder.addAction(
+                        android.R.drawable.ic_media_next,
+                        "Next",
+                        _mediaAction(ACTION_NEXT)
+                )
             }
         } else {
             builder.setContentTitle(getString(R.string.notification_title))
-                .setContentText(getString(R.string.notification_text))
+                    .setContentText(getString(R.string.notification_text))
         }
         return builder.build()
     }
 
     private fun _mediaAction(action: String): PendingIntent {
         val intent = Intent(action).setPackage(packageName)
-        return PendingIntent.getBroadcast(this, action.hashCode(), intent,
-            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
+        return PendingIntent.getBroadcast(
+                this,
+                action.hashCode(),
+                intent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
     }
 
     private fun _updateMediaNotification() {
@@ -515,7 +596,11 @@ class AirPlayService : Service(), RaopCallbackHandler {
         nm.notify(NOTIFICATION_ID, _buildMediaNotification())
     }
 
-    enum class ServerState { STOPPED, RUNNING, ERROR }
+    enum class ServerState {
+        STOPPED,
+        RUNNING,
+        ERROR
+    }
 
     companion object {
         private const val TAG = "AirPlayService"

--- a/app/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
@@ -297,6 +297,9 @@ class AirPlayService : Service(), RaopCallbackHandler {
     override fun onConnectionInit() {
         _connectionCount.value++
         log("Client connected (${_connectionCount.value})")
+        val launchIntent = Intent(this, MainActivity::class.java)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+        try { startActivity(launchIntent) } catch (e: Exception) { Log.w(TAG, "UI launch failed", e) }
     }
 
     override fun onConnectionDestroy() {

--- a/app/src/main/kotlin/io/github/jqssun/airplay/ui/MainScreen.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/ui/MainScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Article
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -59,9 +60,9 @@ fun MainScreen(
         if (audioOnly && !autoAudioMode) showModePrompt = true
     }
 
-    // Auto fullscreen when client connects (non-audio)
-    LaunchedEffect(connections, audioOnly) {
-        if (connections > 0 && !audioOnly && autoFullscreen && !fullscreen) {
+    // Auto fullscreen when client connects (non-audio), but never while a PIN is pending.
+    LaunchedEffect(connections, audioOnly, pin) {
+        if (connections > 0 && !audioOnly && autoFullscreen && !fullscreen && pin == null) {
             fullscreen = true
         }
     }
@@ -101,6 +102,11 @@ fun MainScreen(
         }
     }
 
+    // Exit fullscreen while a PIN is being shown so the dialog isn't covered.
+    LaunchedEffect(pin) {
+        if (pin != null) fullscreen = false
+    }
+
     if (fullscreen) {
         BackHandler { fullscreen = false }
         FullscreenVideo(
@@ -111,43 +117,42 @@ fun MainScreen(
             onExitFullscreen = { fullscreen = false },
             onPip = onPip
         )
-        return
-    }
-
-    Scaffold(
-        bottomBar = {
-            NavigationBar {
-                NavigationBarItem(
-                    selected = tab == Tab.OVERVIEW,
-                    onClick = { tab = Tab.OVERVIEW },
-                    icon = { Icon(Icons.Default.Cast, null) },
-                    label = { Text(stringResource(Tab.OVERVIEW.labelRes)) }
-                )
-                NavigationBarItem(
-                    selected = tab == Tab.LOGS,
-                    onClick = { tab = Tab.LOGS },
-                    icon = { Icon(Icons.Default.Article, null) },
-                    label = { Text(stringResource(Tab.LOGS.labelRes)) }
-                )
-                NavigationBarItem(
-                    selected = tab == Tab.SETTINGS,
-                    onClick = { tab = Tab.SETTINGS },
-                    icon = { Icon(Icons.Default.Settings, null) },
-                    label = { Text(stringResource(Tab.SETTINGS.labelRes)) }
-                )
+    } else {
+        Scaffold(
+            bottomBar = {
+                NavigationBar {
+                    NavigationBarItem(
+                        selected = tab == Tab.OVERVIEW,
+                        onClick = { tab = Tab.OVERVIEW },
+                        icon = { Icon(Icons.Default.Cast, null) },
+                        label = { Text(stringResource(Tab.OVERVIEW.labelRes)) }
+                    )
+                    NavigationBarItem(
+                        selected = tab == Tab.LOGS,
+                        onClick = { tab = Tab.LOGS },
+                        icon = { Icon(Icons.AutoMirrored.Filled.Article, null) },
+                        label = { Text(stringResource(Tab.LOGS.labelRes)) }
+                    )
+                    NavigationBarItem(
+                        selected = tab == Tab.SETTINGS,
+                        onClick = { tab = Tab.SETTINGS },
+                        icon = { Icon(Icons.Default.Settings, null) },
+                        label = { Text(stringResource(Tab.SETTINGS.labelRes)) }
+                    )
+                }
             }
-        }
-    ) { padding ->
-        Box(modifier = Modifier.padding(padding)) {
-            when (tab) {
-                Tab.OVERVIEW -> OverviewContent(
-                    viewModel, onSurfaceAvailable, onSurfaceDestroyed,
-                    onFullscreen = { fullscreen = true },
-                    onPip = onPip,
-                    showAudioMode = audioOnly
-                )
-                Tab.LOGS -> LogsScreen(viewModel)
-                Tab.SETTINGS -> SettingsScreen(viewModel)
+        ) { padding ->
+            Box(modifier = Modifier.padding(padding)) {
+                when (tab) {
+                    Tab.OVERVIEW -> OverviewContent(
+                        viewModel, onSurfaceAvailable, onSurfaceDestroyed,
+                        onFullscreen = { fullscreen = true },
+                        onPip = onPip,
+                        showAudioMode = audioOnly
+                    )
+                    Tab.LOGS -> LogsScreen(viewModel)
+                    Tab.SETTINGS -> SettingsScreen(viewModel)
+                }
             }
         }
     }

--- a/app/src/main/kotlin/io/github/jqssun/airplay/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/ui/SettingsScreen.kt
@@ -1,5 +1,11 @@
 package io.github.jqssun.airplay.ui
 
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
@@ -9,10 +15,14 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import io.github.jqssun.airplay.R
 import io.github.jqssun.airplay.viewmodel.MainViewModel
 import androidx.compose.ui.res.stringResource
@@ -28,6 +38,7 @@ fun SettingsScreen(viewModel: MainViewModel) {
     val idlePreview by viewModel.idlePreview.collectAsState()
     val autoFullscreen by viewModel.autoFullscreen.collectAsState()
     val autoAudioMode by viewModel.autoAudioMode.collectAsState()
+    val launchOnConnect by viewModel.launchOnConnect.collectAsState()
     val maxFps by viewModel.maxFps.collectAsState()
     val overscanned by viewModel.overscanned.collectAsState()
     val requirePin by viewModel.requirePin.collectAsState()
@@ -138,6 +149,39 @@ fun SettingsScreen(viewModel: MainViewModel) {
             onCheckedChange = { viewModel.setAutoAudioMode(it) }
         )
 
+        val ctx = LocalContext.current
+        val lifecycleOwner = LocalLifecycleOwner.current
+        var hasOverlayPermission by remember { mutableStateOf(canAutoLaunch(ctx)) }
+        DisposableEffect(lifecycleOwner) {
+            val observer = LifecycleEventObserver { _, event ->
+                if (event == Lifecycle.Event.ON_RESUME) hasOverlayPermission = canAutoLaunch(ctx)
+            }
+            lifecycleOwner.lifecycle.addObserver(observer)
+            onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+        }
+        val needsOverlayPermission = launchOnConnect && !hasOverlayPermission
+        ListItem(
+            modifier = if (needsOverlayPermission) {
+                Modifier.clickable { ctx.startActivity(_overlayIntent(ctx)) }
+            } else Modifier,
+            headlineContent = { Text(stringResource(R.string.setting_launch_on_connect)) },
+            supportingContent = {
+                Text(stringResource(
+                    if (needsOverlayPermission) R.string.setting_launch_on_connect_no_permission
+                    else R.string.setting_launch_on_connect_desc
+                ))
+            },
+            trailingContent = {
+                Switch(
+                    checked = launchOnConnect,
+                    onCheckedChange = {
+                        viewModel.setLaunchOnConnect(it)
+                        if (it && !canAutoLaunch(ctx)) ctx.startActivity(_overlayIntent(ctx))
+                    }
+                )
+            }
+        )
+
         SettingResolution(
             value = resolution,
             onValueChange = { viewModel.setResolution(it) }
@@ -225,6 +269,13 @@ fun SettingsScreen(viewModel: MainViewModel) {
         )
     }
 }
+
+private fun canAutoLaunch(ctx: Context): Boolean =
+    Build.VERSION.SDK_INT < Build.VERSION_CODES.Q || Settings.canDrawOverlays(ctx)
+
+private fun _overlayIntent(ctx: Context): Intent =
+    Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION, Uri.parse("package:${ctx.packageName}"))
+        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
 
 @Composable
 private fun SectionHeader(title: String) {

--- a/app/src/main/kotlin/io/github/jqssun/airplay/viewmodel/MainViewModel.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/viewmodel/MainViewModel.kt
@@ -106,6 +106,9 @@ class MainViewModel @Inject constructor(app: Application) : AndroidViewModel(app
     private val _autoAudioMode = MutableStateFlow(prefs.getBoolean(Prefs.AUTO_AUDIO_MODE, Prefs.DEF_AUTO_AUDIO_MODE))
     val autoAudioMode: StateFlow<Boolean> = _autoAudioMode.asStateFlow()
 
+    private val _launchOnConnect = MutableStateFlow(prefs.getBoolean(Prefs.LAUNCH_ON_CONNECT, Prefs.DEF_LAUNCH_ON_CONNECT))
+    val launchOnConnect: StateFlow<Boolean> = _launchOnConnect.asStateFlow()
+
     // Debug
     private val _debugEnabled = MutableStateFlow(prefs.getBoolean(Prefs.DEBUG_ENABLED, Prefs.DEF_DEBUG_ENABLED))
     val debugEnabled: StateFlow<Boolean> = _debugEnabled.asStateFlow()
@@ -184,6 +187,7 @@ class MainViewModel @Inject constructor(app: Application) : AndroidViewModel(app
     fun setIdlePreview(v: Boolean) { _idlePreview.value = v; prefs.edit().putBoolean(Prefs.IDLE_PREVIEW, v).apply() }
     fun setAutoFullscreen(v: Boolean) { _autoFullscreen.value = v; prefs.edit().putBoolean(Prefs.AUTO_FULLSCREEN, v).apply() }
     fun setAutoAudioMode(v: Boolean) { _autoAudioMode.value = v; prefs.edit().putBoolean(Prefs.AUTO_AUDIO_MODE, v).apply() }
+    fun setLaunchOnConnect(v: Boolean) { _launchOnConnect.value = v; prefs.edit().putBoolean(Prefs.LAUNCH_ON_CONNECT, v).apply() }
     fun setDebugEnabled(v: Boolean) { _debugEnabled.value = v; prefs.edit().putBoolean(Prefs.DEBUG_ENABLED, v).apply() }
 
     // Service binding

--- a/app/src/main/res/drawable/banner.xml
+++ b/app/src/main/res/drawable/banner.xml
@@ -1,0 +1,39 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="320dp"
+    android:height="180dp"
+    android:viewportWidth="320"
+    android:viewportHeight="180">
+
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M0,0h320v180H0z" />
+
+    <group
+        android:scaleX="0.1875"
+        android:scaleY="0.1875"
+        android:translateX="70">
+        <group
+            android:pivotX="480"
+            android:pivotY="480"
+            android:scaleX="0.5"
+            android:scaleY="0.5">
+            <group
+                android:translateX="16"
+                android:translateY="16">
+                <path
+                    android:fillColor="#C0C0C0"
+                    android:pathData="m240,840 l240,-240 l240,240L240,840ZM80,680v-480q0,-33 23.5,-56.5T160,120h640q33,0 56.5,23.5T880,200v480q0,33 -23.5,56.5T800,760H680v-80h120v-480H160v480h120v80H160q-33,0 -56.5,-23.5T80,680Zm400,-200Z" />
+            </group>
+            <group
+                android:translateX="12"
+                android:translateY="12">
+                <path
+                    android:fillColor="#9E9E9E"
+                    android:pathData="m240,840 l240,-240 l240,240L240,840ZM80,680v-480q0,-33 23.5,-56.5T160,120h640q33,0 56.5,23.5T880,200v480q0,33 -23.5,56.5T800,760H680v-80h120v-480H160v480h120v80H160q-33,0 -56.5,-23.5T80,680Zm400,-200Z" />
+            </group>
+            <path
+                android:fillColor="#424242"
+                android:pathData="m240,840 l240,-240 l240,240L240,840ZM80,680v-480q0,-33 23.5,-56.5T160,120h640q33,0 56.5,23.5T880,200v480q0,33 -23.5,56.5T800,760H680v-80h120v-480H160v480h120v80H160q-33,0 -56.5,-23.5T80,680Zm400,-200Z" />
+        </group>
+    </group>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,6 +73,9 @@
     <string name="setting_auto_fullscreen_desc">Enter fullscreen when a client connects</string>
     <string name="setting_auto_audio_mode">Enter audio mode automatically</string>
     <string name="setting_auto_audio_mode_desc">Skip the prompt when switching to audio mode</string>
+    <string name="setting_launch_on_connect">Open this application on connect</string>
+    <string name="setting_launch_on_connect_desc">Show the screen when a client connects</string>
+    <string name="setting_launch_on_connect_no_permission">Tap to grant Display over other apps permission</string>
     <string name="setting_resolution">Resolution</string>
     <string name="setting_resolution_desc">Video resolution advertised to clients</string>
     <string name="setting_resolution_placeholder">[W]x[H]</string>


### PR DESCRIPTION
Without an Activity providing a video Surface, mirror connections succeed at the protocol level but render no picture. Launching MainActivity on connect ensures the surface is available.