### PR TITLE
Add armeabi-v7a to ABI filters

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,7 +36,7 @@ android {
         versionName = "0.0.7"
 
         ndk {
-            abiFilters += listOf("arm64-v8a", "x86_64")
+            abiFilters += listOf("arm64-v8a", "x86_64", "armeabi-v7a")
         }
 
         externalNativeBuild {


### PR DESCRIPTION
Allows the APK to install on devices that only expose 32-bit userspace despite 64-bit-capable hardware (Fire TV Stick 4K Max is the case I hit). CMake build is portable and compiles cleanly for v7a.