### PR TITLE
fix airplay volume barely doing anything

### DIFF
--- a/app/src/main/kotlin/io/github/jqssun/airplay/renderer/AudioRenderer.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/renderer/AudioRenderer.kt
@@ -8,6 +8,7 @@ import android.media.MediaFormat
 import android.util.Log
 import io.github.jqssun.airplay.bridge.NativeBridge
 import java.nio.ByteBuffer
+import kotlin.math.pow
 
 class AudioRenderer {
 
@@ -21,8 +22,15 @@ class AudioRenderer {
     @Volatile var realtimeDecoderPriority = true
     @Volatile var volume = 1.0f; private set
     @Volatile var codecLabel = ""; private set
+    @Volatile private var pendingReset = false
+
+    fun markSessionEnded() { pendingReset = true }
 
     fun feedAudio(data: ByteArray, ct: Int, ntpTimeNs: Long) {
+        if (pendingReset) {
+            pendingReset = false
+            stop()
+        }
         if (ct != currentCt || (codec == null && swAlacHandle == 0L)) {
             if (ct == failedCt) {
                 if (!_ensureSoftwareAlac(ct)) return
@@ -184,9 +192,12 @@ class AudioRenderer {
     }
 
     fun setVolume(vol: Float) {
-        volume = if (vol <= -144f) 0f
-                 else if (vol >= 0f) 1f
-                 else (vol + 144f) / 144f
+        // max: 0; min: -30; mute: -144
+        volume = when {
+            vol <= -144f -> 0f
+            vol >= 0f -> 1f
+            else -> 10f.pow(vol / 20f)
+        }
         track?.setVolume(volume)
     }
 

--- a/app/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
@@ -371,11 +371,13 @@ class AirPlayService : Service(), RaopCallbackHandler {
             _positionMs.value = 0
             _durationMs.value = 0
             mediaSession?.isActive = false
+            audioRenderer.markSessionEnded()
         }
         log("Client disconnected (${_connectionCount.value})")
     }
 
     override fun onConnectionReset(reason: Int) {
+        audioRenderer.markSessionEnded()
         log("Connection reset: $reason")
     }
 


### PR DESCRIPTION
noticed the volume from my mac barely changed anything when airplaying audio to the tv. turned out `setVolume` divides the dB value by 144, but airplay's usable range is only -30..0 (with -144 = mute), so the whole slider got squished into ~0.79..1.0 gain.

switched it to convert dB -> linear gain (`10^(db/20)`), same as uxplay. full range works now. tested on a xiaomi box streaming from macos.
