### PR TITLE
Keep screen on during active mirroring (fixes #9)

### DIFF
--- a/app/src/main/kotlin/io/github/jqssun/airplay/ui/MainScreen.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/ui/MainScreen.kt
@@ -1,6 +1,7 @@
 package io.github.jqssun.airplay.ui
 
 import android.app.Activity
+import android.view.WindowManager
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.Image
@@ -86,6 +87,18 @@ fun MainScreen(
     }
 
     val activity = LocalContext.current as? Activity
+
+    // keep the display awake (and the screensaver/daydream away) while a video
+    // client is mirroring; released when no video session is active
+    LaunchedEffect(connections, audioOnly) {
+        val window = activity?.window ?: return@LaunchedEffect
+        if (connections > 0) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        } else {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+    }
+
     LaunchedEffect(fullscreen) {
         val window = activity?.window ?: return@LaunchedEffect
         val controller = WindowInsetsControllerCompat(window, window.decorView)


### PR DESCRIPTION
## What
Adds `FLAG_KEEP_SCREEN_ON` to the main activity window while an AirPlay client is connected, and clears it on disconnect.

## Why
On Android TV (and phones), the system screensaver/daydream and screen timeout fire after the idle-input timeout. Rendering AirPlay frames to a Surface is not treated as user input, so the display sleeps mid-session and interrupts the stream, i.e. the behaviour reported in #9.

The app previously held only a `PARTIAL_WAKE_LOCK`, which keeps the CPU running but does not keep the display on.

## How
A `LaunchedEffect(connections, audioOnly)` in `MainScreen` adds `FLAG_KEEP_SCREEN_ON` when `connections > 0` and clears it otherwise. This is scoped to connection state rather than the mirror `SurfaceView` (which is always present on the Overview tab); an unconditional flag would hold the screen on the entire time the app is open. The display is held awake for any active session, video mirroring or audio-only, and released on full disconnect, restoring the normal OS timeout when idle.

## Possible follow-up
This could be exposed as a setting (e.g. "Keep screen on while mirroring"), for users who would prefer to let the display sleep or to scope it to video-only sessions. Happy to add that if preferred.

Fixes #9
