### PR TITLE
TV-remote transport controls for AirPlay Video playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Check out the [CI](https://github.com/jqssun/android-airplay-server/blob/main/.g
 
 - [UxPlay](https://github.com/FDH2/UxPlay) for the AirPlay/RAOP server implementation
 - [ALAC](https://github.com/macosforge/alac) for the lossless audio decoder
-
+- [Next Player](https://github.com/anilbeesetti/nextplayer) for the video player
 
 ---
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,7 +14,7 @@ val localProps = Properties().apply {
 
 android {
     namespace = "io.github.jqssun.airplay"
-    compileSdk = 35
+    compileSdk = 36
     ndkVersion = "27.0.12077973"
 
     if (localProps.containsKey("storeFile")) {
@@ -32,8 +32,8 @@ android {
         applicationId = "io.github.jqssun.airplay"
         minSdk = 24
         targetSdk = 35
-        versionCode = 19
-        versionName = "0.0.19"
+        versionCode = 20
+        versionName = "0.0.20"
 
         ndk {
             abiFilters += listOf("arm64-v8a", "armeabi-v7a", "x86_64")

--- a/app/src/main/kotlin/io/github/jqssun/airplay/MainActivity.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/MainActivity.kt
@@ -11,7 +11,6 @@ import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
 import android.util.Rational
-import android.view.KeyEvent
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -104,59 +103,6 @@ class MainActivity : ComponentActivity() {
                 )
             }
         }
-    }
-
-    // nothing in the video screen takes focus, so dispatchKeyEvent is the interception point
-    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
-        if (service?.videoPlaybackActive?.value == true && _handleVideoKeyEvent(event)) return true
-        return super.dispatchKeyEvent(event)
-    }
-
-    private fun _handleVideoKeyEvent(event: KeyEvent): Boolean {
-        val handled = when (event.keyCode) {
-            KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE,
-            KeyEvent.KEYCODE_MEDIA_PLAY,
-            KeyEvent.KEYCODE_MEDIA_PAUSE,
-            KeyEvent.KEYCODE_DPAD_CENTER,
-            KeyEvent.KEYCODE_ENTER,
-            KeyEvent.KEYCODE_NUMPAD_ENTER,
-            KeyEvent.KEYCODE_DPAD_LEFT,
-            KeyEvent.KEYCODE_DPAD_RIGHT,
-            KeyEvent.KEYCODE_DPAD_UP,
-            KeyEvent.KEYCODE_DPAD_DOWN,
-            KeyEvent.KEYCODE_MEDIA_REWIND,
-            KeyEvent.KEYCODE_MEDIA_FAST_FORWARD,
-            KeyEvent.KEYCODE_MEDIA_STOP,
-            KeyEvent.KEYCODE_BACK -> true
-            else -> false
-        }
-        if (!handled) return false
-        // consume matching UP events too so they can't leak into the UI underneath
-        if (event.action != KeyEvent.ACTION_DOWN) return true
-        when (event.keyCode) {
-            KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE,
-            KeyEvent.KEYCODE_DPAD_CENTER,
-            KeyEvent.KEYCODE_ENTER,
-            KeyEvent.KEYCODE_NUMPAD_ENTER ->
-                if (event.repeatCount == 0) viewModel.toggleVideoPlayPause()
-            KeyEvent.KEYCODE_MEDIA_PLAY ->
-                if (event.repeatCount == 0) viewModel.setVideoPlaying(true)
-            KeyEvent.KEYCODE_MEDIA_PAUSE ->
-                if (event.repeatCount == 0) viewModel.setVideoPlaying(false)
-            KeyEvent.KEYCODE_DPAD_LEFT,
-            KeyEvent.KEYCODE_MEDIA_REWIND ->
-                viewModel.scrubVideoBy(-1, event.repeatCount)
-            KeyEvent.KEYCODE_DPAD_RIGHT,
-            KeyEvent.KEYCODE_MEDIA_FAST_FORWARD ->
-                viewModel.scrubVideoBy(1, event.repeatCount)
-            KeyEvent.KEYCODE_DPAD_UP,
-            KeyEvent.KEYCODE_DPAD_DOWN ->
-                if (event.repeatCount == 0) viewModel.showVideoOverlay()
-            KeyEvent.KEYCODE_MEDIA_STOP,
-            KeyEvent.KEYCODE_BACK ->
-                if (event.repeatCount == 0) viewModel.stopVideoPlayback()
-        }
-        return true
     }
 
     fun enterPip() {

--- a/app/src/main/kotlin/io/github/jqssun/airplay/renderer/AirPlayVideoPlayer.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/renderer/AirPlayVideoPlayer.kt
@@ -7,11 +7,25 @@ import android.util.Log
 import android.view.Surface
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
 import androidx.media3.common.VideoSize
 import androidx.media3.exoplayer.ExoPlayer
+
+// rate is 0 while buffering; speed is the configured rate regardless of pause state
+// native reads the effective rate, overlay reads playWhenReady + speed + skipSilence
+data class PlaybackSnapshot(
+    val position: Float,
+    val duration: Float,
+    val rate: Float,
+    val ready: Boolean,
+    val playWhenReady: Boolean,
+    val speed: Float = 1f,
+    val skipSilence: Boolean = false,
+    val buffering: Boolean = false,
+)
 
 // exoplayer calls stay on the main thread; native only reads the onPlaybackInfo snapshot
 class AirPlayVideoPlayer(private val context: Context) {
@@ -20,9 +34,9 @@ class AirPlayVideoPlayer(private val context: Context) {
     private var player: ExoPlayer? = null
     private var pendingSurface: Surface? = null
 
-    // rate is 0 while buffering; overlay wants logical playWhenReady, native the effective rate
-    var onPlaybackInfo: ((position: Float, duration: Float, rate: Float, readyToPlay: Boolean, playWhenReady: Boolean) -> Unit)? = null
-    var onVideoAspect: ((Float) -> Unit)? = null
+    var onPlaybackInfo: ((PlaybackSnapshot) -> Unit)? = null
+    var onVideoSize: ((width: Int, height: Int, aspect: Float) -> Unit)? = null
+    var onTitle: ((String?) -> Unit)? = null
     var onEnded: (() -> Unit)? = null
 
     private val _reportTick = object : Runnable {
@@ -44,9 +58,13 @@ class AirPlayVideoPlayer(private val context: Context) {
             // duration is usually established here (esp. hls): report so the held /play releases
             _reportPlaybackInfo()
         }
+        override fun onMediaMetadataChanged(mediaMetadata: MediaMetadata) {
+            onTitle?.invoke(mediaMetadata.title?.toString())
+        }
         override fun onVideoSizeChanged(videoSize: VideoSize) {
             if (videoSize.height == 0) return
-            onVideoAspect?.invoke(videoSize.width * videoSize.pixelWidthHeightRatio / videoSize.height)
+            val width = (videoSize.width * videoSize.pixelWidthHeightRatio).toInt()
+            onVideoSize?.invoke(width, videoSize.height, width.toFloat() / videoSize.height)
         }
     }
 
@@ -61,12 +79,18 @@ class AirPlayVideoPlayer(private val context: Context) {
         p.setMediaItem(MediaItem.fromUri(location), (startPositionSeconds * 1000).toLong())
         p.playWhenReady = true
         p.prepare()
-        onPlaybackInfo?.invoke(startPositionSeconds, 0f, 0f, false, true)
+        onPlaybackInfo?.invoke(PlaybackSnapshot(startPositionSeconds, 0f, 0f, false, true))
         mainHandler.postDelayed(_reportTick, REPORT_INTERVAL_MS)
     }
 
     fun scrub(positionSeconds: Float) = mainHandler.post {
         player?.seekTo((positionSeconds * 1000).toLong())
+    }
+
+    // coalesces the seek spam from drag-seeking
+    @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+    fun setScrubbing(enabled: Boolean) = mainHandler.post {
+        player?.isScrubbingModeEnabled = enabled
     }
 
     fun setRate(rate: Float) = mainHandler.post {
@@ -82,6 +106,15 @@ class AirPlayVideoPlayer(private val context: Context) {
     // local-only: the sender self-syncs from its next /playback-info poll
     fun setPlaying(playing: Boolean) = mainHandler.post {
         player?.playWhenReady = playing
+    }
+
+    // local speed toggle: unlike setRate it must not resume a paused player
+    fun setSpeed(speed: Float) = mainHandler.post {
+        player?.playbackParameters = PlaybackParameters(speed.coerceAtLeast(0.1f))
+    }
+
+    fun setSkipSilence(enabled: Boolean) = mainHandler.post {
+        player?.skipSilenceEnabled = enabled
     }
 
     fun seekBy(deltaMs: Long) = mainHandler.post {
@@ -117,7 +150,7 @@ class AirPlayVideoPlayer(private val context: Context) {
         player = null
         // duration=-1 is the "video finished" sentinel for the playback-info handler
         if (reportStopped) {
-            onPlaybackInfo?.invoke(0f, -1f, 0f, false, false)
+            onPlaybackInfo?.invoke(PlaybackSnapshot(0f, -1f, 0f, false, false))
         }
     }
 
@@ -131,7 +164,18 @@ class AirPlayVideoPlayer(private val context: Context) {
         // readyToPlay = the timeline is established, NOT exoplayer's buffering state: for vod that means the duration is known; for live there is no duration so being playable is enough. the sender holds its timeline (and /play) until this, so it must not go true early
         val ready = if (p.isCurrentMediaItemLive) p.playbackState == Player.STATE_READY
                     else durationMs != C.TIME_UNSET
-        onPlaybackInfo?.invoke(position, duration, rate, ready, p.playWhenReady)
+        onPlaybackInfo?.invoke(
+            PlaybackSnapshot(
+                position = position,
+                duration = duration,
+                rate = rate,
+                ready = ready,
+                playWhenReady = p.playWhenReady,
+                speed = p.playbackParameters.speed,
+                skipSilence = p.skipSilenceEnabled,
+                buffering = p.playbackState == Player.STATE_BUFFERING,
+            )
+        )
     }
 
     companion object {

--- a/app/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
@@ -50,6 +50,9 @@ data class VideoPlaybackInfo(
     val positionMs: Long = 0,
     val durationMs: Long = 0,
     val playing: Boolean = true,
+    val speed: Float = 1f,
+    val skipSilence: Boolean = false,
+    val buffering: Boolean = false,
 )
 
 class AirPlayService : Service(), RaopCallbackHandler {
@@ -63,7 +66,10 @@ class AirPlayService : Service(), RaopCallbackHandler {
     val audioRenderer = AudioRenderer()
     val airPlayVideoPlayer by lazy { AirPlayVideoPlayer(this) }
     val videoDownloader by lazy { VideoDownloader(this) }
-    @Volatile private var _videoLocation: String? = null
+
+    // hls urls point at the native httpd, valid only while the session lives
+    private val _videoLocation = MutableStateFlow<String?>(null)
+    val videoLocation = _videoLocation.asStateFlow()
 
     private val _serverState = MutableStateFlow(ServerState.STOPPED)
     val serverState = _serverState.asStateFlow()
@@ -92,6 +98,13 @@ class AirPlayService : Service(), RaopCallbackHandler {
 
     private val _videoPlaybackAspect = MutableStateFlow(16f / 9f)
     val videoPlaybackAspect = _videoPlaybackAspect.asStateFlow()
+
+    private val _videoPlaybackSize = MutableStateFlow<Pair<Int, Int>?>(null)
+    val videoPlaybackSize = _videoPlaybackSize.asStateFlow()
+
+    // container/manifest metadata
+    private val _videoTitle = MutableStateFlow("")
+    val videoTitle = _videoTitle.asStateFlow()
 
     // recent /playback-info polls with no playback = pending video; polls start ~1s before /play
     @Volatile private var _lastVideoPollAt = 0L
@@ -213,18 +226,25 @@ class AirPlayService : Service(), RaopCallbackHandler {
         }
         ContextCompat.registerReceiver(this, mediaReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
 
-        airPlayVideoPlayer.onVideoAspect = { _videoPlaybackAspect.value = it }
+        airPlayVideoPlayer.onVideoSize = { width, height, aspect ->
+            _videoPlaybackAspect.value = aspect
+            _videoPlaybackSize.value = width to height
+        }
+        airPlayVideoPlayer.onTitle = { _videoTitle.value = it ?: "" }
         airPlayVideoPlayer.onEnded = { _endVideoPlayback("AirPlay Video stopped (player)") }
-        airPlayVideoPlayer.onPlaybackInfo = { position, duration, rate, ready, playWhenReady ->
+        airPlayVideoPlayer.onPlaybackInfo = { snapshot ->
             if (nativeHandle != 0L) {
-                NativeBridge.nativeUpdatePlaybackInfo(nativeHandle, position, duration, rate, ready)
+                NativeBridge.nativeUpdatePlaybackInfo(nativeHandle, snapshot.position, snapshot.duration, snapshot.rate, snapshot.ready)
             }
             if (_videoPlaybackActive.value) {
-                _updateVideoPlaybackState(position, rate)
+                _updateVideoPlaybackState(snapshot.position, snapshot.rate)
                 _videoPlaybackInfo.value = VideoPlaybackInfo(
-                    positionMs = (position * 1000).toLong(),
-                    durationMs = if (duration > 0f) (duration * 1000).toLong() else 0L,
-                    playing = playWhenReady,
+                    positionMs = (snapshot.position * 1000).toLong(),
+                    durationMs = if (snapshot.duration > 0f) (snapshot.duration * 1000).toLong() else 0L,
+                    playing = snapshot.playWhenReady,
+                    speed = snapshot.speed,
+                    skipSilence = snapshot.skipSilence,
+                    buffering = snapshot.buffering,
                 )
             }
         }
@@ -406,11 +426,26 @@ class AirPlayService : Service(), RaopCallbackHandler {
         airPlayVideoPlayer.scrub(positionMs / 1000f)
     }
 
+    fun setVideoScrubbing(enabled: Boolean) {
+        airPlayVideoPlayer.setScrubbing(enabled)
+    }
+
+    fun setVideoSpeed(speed: Float) {
+        airPlayVideoPlayer.setSpeed(speed)
+    }
+
+    fun setVideoSkipSilence(enabled: Boolean) {
+        airPlayVideoPlayer.setSkipSilence(enabled)
+    }
+
+    fun seekVideoBy(deltaMs: Long) {
+        airPlayVideoPlayer.seekBy(deltaMs)
+    }
+
     fun stopVideoPlayback() = _endVideoPlayback("AirPlay Video stopped (local)")
 
-    // hls urls point at the native httpd, valid only while the session lives
     fun downloadVideo() {
-        _videoLocation?.let { videoDownloader.start(it) }
+        _videoLocation.value?.let { videoDownloader.start(it) }
     }
 
     private fun _endVideoPlayback(message: String) {
@@ -451,11 +486,13 @@ class AirPlayService : Service(), RaopCallbackHandler {
     }
 
     override fun onVideoPlay(location: String, startPositionSeconds: Float) {
-        _videoLocation = location
+        _videoLocation.value = location
         _videoPlaySeq.value++
         _videoPollSuppressed = false
         _videoPlaybackInfo.value = VideoPlaybackInfo(positionMs = (startPositionSeconds * 1000).toLong())
         _videoPlaybackAspect.value = 16f / 9f
+        _videoPlaybackSize.value = null
+        _videoTitle.value = ""
         _videoPlaybackActive.value = true
         airPlayVideoPlayer.play(location, startPositionSeconds)
         // claim media-button routing for keys that arrive as media-session events
@@ -827,8 +864,8 @@ class AirPlayService : Service(), RaopCallbackHandler {
         const val ACTION_NEXT = "io.github.jqssun.airplay.NEXT"
         const val ACTION_PREV = "io.github.jqssun.airplay.PREV"
         const val ACTION_START_SERVER = "io.github.jqssun.airplay.START_SERVER"
-        // single-press seek step, shared with the dpad scrub ramp's first tier
-        const val VIDEO_SEEK_STEP_MS = 5_000L
+        // shared with dpad/double-tap seeks
+        const val VIDEO_SEEK_STEP_MS = 10_000L
         const val VIDEO_POLL_PENDING_TIMEOUT_MS = 3_000L
     }
 }

--- a/app/src/main/kotlin/io/github/jqssun/airplay/ui/MainScreen.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/ui/MainScreen.kt
@@ -1,28 +1,34 @@
 package io.github.jqssun.airplay.ui
 
 import android.app.Activity
+import android.content.pm.ActivityInfo
+import android.content.pm.PackageManager
+import android.content.res.Configuration
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Article
+import androidx.compose.material.icons.automirrored.rounded.VolumeUp
 import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.rounded.BrightnessHigh
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
@@ -30,8 +36,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -40,10 +44,23 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import io.github.jqssun.airplay.R
 import io.github.jqssun.airplay.service.AirPlayService.ServerState
+import io.github.jqssun.airplay.ui.gestures.BrightnessState
+import io.github.jqssun.airplay.ui.gestures.DoubleTapIndicator
+import io.github.jqssun.airplay.ui.gestures.GestureInfoText
+import io.github.jqssun.airplay.ui.gestures.SeekGestureState
+import io.github.jqssun.airplay.ui.gestures.TapGestureState
+import io.github.jqssun.airplay.ui.gestures.VerticalGesture
+import io.github.jqssun.airplay.ui.gestures.VideoContentScale
+import io.github.jqssun.airplay.ui.gestures.VerticalProgressIndicator
+import io.github.jqssun.airplay.ui.gestures.VideoPlayerGestures
+import io.github.jqssun.airplay.ui.gestures.VolumeAndBrightnessGestureState
+import io.github.jqssun.airplay.ui.gestures.VolumeState
+import io.github.jqssun.airplay.ui.gestures.ZoomState
 import io.github.jqssun.airplay.viewmodel.DebugInfo
 import io.github.jqssun.airplay.viewmodel.MainViewModel
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import kotlin.math.abs
 import kotlinx.coroutines.delay
 
 private enum class Tab(val labelRes: Int, val icon: ImageVector) {
@@ -161,33 +178,295 @@ fun MainScreen(
                 }
             }
         }
+        val gestureScope = rememberCoroutineScope()
+        val tapGestureState = remember(viewModel) { TapGestureState(viewModel, gestureScope) }
+        val seekGestureState = remember(viewModel) { SeekGestureState(viewModel) }
+        val context = LocalContext.current
+        val volumeState = remember { VolumeState(context) }
+        val brightnessState = remember(activity) { activity?.window?.let { BrightnessState(it) } }
+        val volumeAndBrightnessGestureState = remember(volumeState, brightnessState) {
+            VolumeAndBrightnessGestureState(volumeState, brightnessState, gestureScope)
+        }
+        val zoomState = remember(viewModel) { ZoomState(viewModel, gestureScope) }
+        var controlsLocked by remember { mutableStateOf(false) }
+        DisposableEffect(volumeState) { volumeState.handleLifecycle(this) }
+        LaunchedEffect(overlayTick) {
+            if (overlayTick == 0L) {
+                zoomState.reset()
+                controlsLocked = false
+            }
+        }
+        DisposableEffect(brightnessState) {
+            onDispose { brightnessState?.clearOverride() }
+        }
+        // orientation follows the video aspect; manual rotate holds until the next video
+        LaunchedEffect(videoPlaybackAspect) {
+            activity?.requestedOrientation = if (videoPlaybackAspect < 1f) {
+                ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT
+            } else {
+                ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+            }
+        }
+        DisposableEffect(activity) {
+            onDispose { activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED }
+        }
+        val videoPlaybackSize by viewModel.videoPlaybackSize.collectAsState()
+        val buffering by viewModel.videoBuffering.collectAsState()
+        val videoTitle by viewModel.videoTitle.collectAsState()
+        val videoLocation by viewModel.videoLocation.collectAsState()
+        val speed by viewModel.videoSpeed.collectAsState()
+        val isPipSupported = remember {
+            context.packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)
+        }
+        var showSpeedSelector by remember { mutableStateOf(false) }
+        BackHandler { viewModel.stopVideoPlayback() }
+
+        val rootFocusRequester = remember { FocusRequester() }
+        val playPauseFocusRequester = remember { FocusRequester() }
+        val unlockFocusRequester = remember { FocusRequester() }
+        var isPlayPauseFocused by remember { mutableStateOf(false) }
+        var isUnlockFocused by remember { mutableStateOf(false) }
+        LaunchedEffect(overlayVisible, controlsLocked, showSpeedSelector) {
+            if (showSpeedSelector) return@LaunchedEffect
+            if (!overlayVisible) {
+                runCatching { rootFocusRequester.requestFocus() }
+                return@LaunchedEffect
+            }
+            val locked = controlsLocked
+            val target = if (locked) unlockFocusRequester else playPauseFocusRequester
+            target.requestFocusUntilLanded(attempts = 20) { if (locked) isUnlockFocused else isPlayPauseFocused }
+        }
+
+        // dpad seeking (controls hidden): accumulate the skipped amount and briefly show it
+        var dpadSeekOffsetMs by remember { mutableLongStateOf(0L) }
+        var dpadSeekTargetMs by remember { mutableLongStateOf(0L) }
+        var dpadSeekActive by remember { mutableStateOf(false) }
+        var dpadSeekTick by remember { mutableIntStateOf(0) }
+        LaunchedEffect(dpadSeekTick) {
+            if (!dpadSeekActive) return@LaunchedEffect
+            delay(1000)
+            dpadSeekActive = false
+        }
+        val showDpadSeekFeedback: (Long) -> Unit = { deltaMs ->
+            if (!dpadSeekActive) dpadSeekOffsetMs = 0L
+            dpadSeekOffsetMs += deltaMs
+            dpadSeekTargetMs = (dpadSeekTargetMs.takeIf { dpadSeekActive } ?: positionMs).plus(deltaMs)
+                .coerceIn(0L, if (durationMs > 0) durationMs else Long.MAX_VALUE)
+            dpadSeekActive = true
+            dpadSeekTick++
+        }
+
         Box(
             modifier = Modifier
                 .fillMaxSize()
                 .background(Color.Black)
-                .pointerInput(Unit) {
-                    detectTapGestures(onTap = {
-                        if (overlayVisible) viewModel.toggleVideoPlayPause()
-                        else viewModel.showVideoOverlay()
-                    })
+                .focusRequester(rootFocusRequester)
+                .focusable()
+                .onPreviewKeyEvent { keyEvent ->
+                    if (showSpeedSelector) {
+                        false
+                    } else {
+                        handlePlayerKeyEvent(
+                            keyEvent = keyEvent,
+                            controlsVisible = overlayVisible,
+                            controlsLocked = controlsLocked,
+                            isPlayPauseFocused = isPlayPauseFocused,
+                            seekIncrementMs = TapGestureState.SEEK_INCREMENT_MS,
+                            viewModel = viewModel,
+                            showControls = { viewModel.showVideoOverlay() },
+                            unlockControls = {
+                                controlsLocked = false
+                                viewModel.showVideoOverlay()
+                            },
+                            onDpadSeek = showDpadSeekFeedback,
+                        )
+                    }
                 },
             contentAlignment = Alignment.Center
         ) {
-            playback()
-            androidx.compose.animation.AnimatedVisibility(
-                visible = overlayVisible,
-                enter = androidx.compose.animation.fadeIn(),
-                exit = androidx.compose.animation.fadeOut(),
-                modifier = Modifier.align(Alignment.BottomCenter)
-            ) {
-                VideoTransportOverlay(
-                    playing = playing && videoPlaybackActive,
-                    positionMs = scrubPositionMs ?: positionMs,
-                    durationMs = durationMs,
-                    downloadProgress = downloadProgress,
-                    onDownload = { viewModel.toggleVideoDownload() }
+            VideoContentFrame(
+                aspect = videoPlaybackAspect,
+                videoSizePx = videoPlaybackSize,
+                contentScale = zoomState.contentScale,
+                zoom = zoomState.zoom
+            ) { sizeModifier ->
+                VideoSurfaceView(
+                    onSurfaceAvailable = { viewModel.onVideoPlaybackSurfaceAvailable(it) },
+                    onSurfaceDestroyed = { viewModel.onVideoPlaybackSurfaceDestroyed(it) },
+                    applyAspectRatio = false,
+                    modifier = sizeModifier
                 )
             }
+            VideoPlayerGestures(
+                enabled = videoPlaybackActive,
+                locked = controlsLocked,
+                onTap = {
+                    // a pending session pins the overlay; taps must not unpin it
+                    if (!videoPlaybackActive) return@VideoPlayerGestures
+                    if (overlayVisible) overlayVisible = false else viewModel.showVideoOverlay()
+                },
+                tapGestureState = tapGestureState,
+                seekGestureState = seekGestureState,
+                volumeAndBrightnessGestureState = volumeAndBrightnessGestureState,
+                zoomState = zoomState
+            )
+            androidx.compose.animation.AnimatedVisibility(
+                visible = overlayVisible && videoPlaybackActive && !controlsLocked,
+                enter = androidx.compose.animation.fadeIn(),
+                exit = androidx.compose.animation.fadeOut()
+            ) {
+                Box(modifier = Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.3f)))
+            }
+            if (buffering) {
+                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center).size(72.dp))
+            }
+            DoubleTapIndicator(tapGestureState = tapGestureState)
+            val seekAmountMs = seekGestureState.seekAmountMs
+            when {
+                seekAmountMs != null -> GestureInfoText(
+                    info = "${if (seekAmountMs < 0) "-" else "+"}${formatVideoTime(abs(seekAmountMs))}\n" +
+                        "[${formatVideoTime(seekGestureState.targetPositionMs ?: 0)}]",
+                    modifier = Modifier.align(Alignment.Center)
+                )
+                zoomState.isZooming -> GestureInfoText(
+                    info = "${(zoomState.zoom * 100).toInt()}%",
+                    modifier = Modifier.align(Alignment.Center)
+                )
+                zoomState.showContentScaleIndicator -> GestureInfoText(
+                    info = stringResource(zoomState.contentScale.nameRes()),
+                    modifier = Modifier.align(Alignment.Center)
+                )
+                else -> androidx.compose.animation.AnimatedVisibility(
+                    visible = overlayVisible && videoPlaybackActive && !controlsLocked,
+                    enter = androidx.compose.animation.fadeIn(),
+                    exit = androidx.compose.animation.fadeOut(),
+                    modifier = Modifier.align(Alignment.Center)
+                ) {
+                    PlayPauseButton(
+                        playing = playing,
+                        onClick = { viewModel.toggleVideoPlayPause() },
+                        modifier = Modifier
+                            .focusRequester(playPauseFocusRequester)
+                            .onFocusChanged { isPlayPauseFocused = it.hasFocus }
+                    )
+                }
+            }
+            DpadSeekIndicator(
+                visible = dpadSeekActive && dpadSeekOffsetMs != 0L,
+                offsetMs = dpadSeekOffsetMs,
+                positionMs = dpadSeekTargetMs
+            )
+            androidx.compose.animation.AnimatedVisibility(
+                visible = volumeAndBrightnessGestureState.activeGesture == VerticalGesture.VOLUME,
+                enter = androidx.compose.animation.fadeIn(),
+                exit = androidx.compose.animation.fadeOut(),
+                modifier = Modifier.align(Alignment.CenterStart).padding(24.dp)
+            ) {
+                VerticalProgressIndicator(value = volumeState.percentage, icon = Icons.AutoMirrored.Rounded.VolumeUp)
+            }
+            androidx.compose.animation.AnimatedVisibility(
+                visible = volumeAndBrightnessGestureState.activeGesture == VerticalGesture.BRIGHTNESS,
+                enter = androidx.compose.animation.fadeIn(),
+                exit = androidx.compose.animation.fadeOut(),
+                modifier = Modifier.align(Alignment.CenterEnd).padding(24.dp)
+            ) {
+                VerticalProgressIndicator(value = brightnessState?.percentage ?: 0, icon = Icons.Rounded.BrightnessHigh)
+            }
+            if (controlsLocked) {
+                if (overlayVisible) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .safeDrawingPadding()
+                            .padding(top = 24.dp)
+                    ) {
+                        UnlockButton(
+                            onClick = {
+                                controlsLocked = false
+                                viewModel.showVideoOverlay()
+                            },
+                            modifier = Modifier
+                                .focusRequester(unlockFocusRequester)
+                                .onFocusChanged { isUnlockFocused = it.hasFocus }
+                        )
+                    }
+                }
+            } else {
+                androidx.compose.animation.AnimatedVisibility(
+                    visible = overlayVisible,
+                    enter = androidx.compose.animation.fadeIn(),
+                    exit = androidx.compose.animation.fadeOut(),
+                    modifier = Modifier.align(Alignment.TopCenter)
+                ) {
+                    VideoControlsTop(
+                        title = videoTitle,
+                        videoUrl = videoLocation,
+                        downloadProgress = downloadProgress,
+                        showDownload = durationMs > 0,
+                        onBackClick = { viewModel.stopVideoPlayback() },
+                        onSpeedClick = {
+                            overlayVisible = false
+                            showSpeedSelector = true
+                        },
+                        onDownloadClick = { viewModel.toggleVideoDownload() }
+                    )
+                }
+                androidx.compose.animation.AnimatedVisibility(
+                    visible = overlayVisible,
+                    enter = androidx.compose.animation.fadeIn(),
+                    exit = androidx.compose.animation.fadeOut(),
+                    modifier = Modifier.align(Alignment.BottomCenter)
+                ) {
+                    VideoControlsBottom(
+                        positionMs = scrubPositionMs ?: positionMs,
+                        durationMs = durationMs,
+                        contentScale = zoomState.contentScale,
+                        isPipSupported = isPipSupported,
+                        onRotateClick = {
+                            activity?.let {
+                                it.requestedOrientation =
+                                    if (it.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+                                        ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT
+                                    } else {
+                                        ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+                                    }
+                            }
+                        },
+                        onLockClick = {
+                            viewModel.showVideoOverlay()
+                            controlsLocked = true
+                        },
+                        onContentScaleClick = {
+                            viewModel.showVideoOverlay()
+                            zoomState.switchToNextContentScale()
+                        },
+                        onPipClick = onPip,
+                        onSeek = { seekGestureState.onSeek(it) },
+                        onSeekEnd = { seekGestureState.onSeekEnd() },
+                        seekBarModifier = Modifier
+                            .focusProperties { up = playPauseFocusRequester }
+                            .dpadAdjust(
+                                onLeft = {
+                                    viewModel.seekVideoBy(-TapGestureState.SEEK_INCREMENT_MS)
+                                    viewModel.showVideoOverlay()
+                                },
+                                onRight = {
+                                    viewModel.seekVideoBy(TapGestureState.SEEK_INCREMENT_MS)
+                                    viewModel.showVideoOverlay()
+                                }
+                            )
+                    )
+                }
+            }
+            val skipSilence by viewModel.videoSkipSilence.collectAsState()
+            PlaybackSpeedSelector(
+                show = showSpeedSelector,
+                speed = speed,
+                skipSilence = skipSilence,
+                onSpeedChange = { viewModel.setVideoSpeed(it) },
+                onSkipSilenceChange = { viewModel.setVideoSkipSilence(it) },
+                onDismiss = { showSpeedSelector = false }
+            )
         }
         return
     }
@@ -539,98 +818,6 @@ private fun FullscreenVideo(
     }
 }
 
-// while scrubbing, positionMs is the pending scrub target, not the live position
-@Composable
-private fun VideoTransportOverlay(
-    playing: Boolean,
-    positionMs: Long,
-    durationMs: Long,
-    downloadProgress: Int?,
-    onDownload: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .background(
-                Brush.verticalGradient(
-                    listOf(Color.Transparent, Color.Black.copy(alpha = 0.75f))
-                )
-            )
-            .padding(horizontal = 40.dp)
-            .padding(top = 48.dp, bottom = 28.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Icon(
-            imageVector = if (playing) Icons.Default.Pause else Icons.Default.PlayArrow,
-            contentDescription = stringResource(R.string.cd_play_pause),
-            tint = Color.White,
-            modifier = Modifier.size(36.dp)
-        )
-        Spacer(Modifier.width(20.dp))
-        // duration 0 = not yet known, or a live stream: no meaningful bar to draw
-        if (durationMs > 0) {
-            // glide between updates so held-key scrubbing reads as one sweep
-            val barFraction by animateFloatAsState(
-                targetValue = (positionMs.toFloat() / durationMs).coerceIn(0f, 1f),
-                animationSpec = tween(durationMillis = 150, easing = LinearEasing),
-                label = "videoSeekBar"
-            )
-            LinearProgressIndicator(
-                progress = { barFraction },
-                color = Color.White,
-                trackColor = Color.White.copy(alpha = 0.3f),
-                drawStopIndicator = {},
-                modifier = Modifier
-                    .weight(1f)
-                    .height(6.dp)
-                    .clip(RoundedCornerShape(3.dp))
-            )
-            Spacer(Modifier.width(20.dp))
-            Text(
-                text = "${_formatTime(positionMs)} / ${_formatTime(durationMs)}",
-                style = MaterialTheme.typography.titleMedium,
-                color = Color.White
-            )
-            Spacer(Modifier.width(12.dp))
-            val cancelCd = stringResource(R.string.cd_cancel_download)
-            IconButton(
-                onClick = onDownload,
-                modifier = if (downloadProgress != null) {
-                    Modifier.semantics { contentDescription = cancelCd }
-                } else Modifier
-            ) {
-                when {
-                    downloadProgress == null -> Icon(
-                        Icons.Default.Download,
-                        contentDescription = stringResource(R.string.cd_download),
-                        tint = Color.White
-                    )
-                    downloadProgress < 0 -> CircularProgressIndicator(
-                        color = Color.White,
-                        strokeWidth = 3.dp,
-                        modifier = Modifier.size(24.dp)
-                    )
-                    else -> CircularProgressIndicator(
-                        progress = { downloadProgress / 100f },
-                        color = Color.White,
-                        trackColor = Color.White.copy(alpha = 0.3f),
-                        strokeWidth = 3.dp,
-                        modifier = Modifier.size(24.dp)
-                    )
-                }
-            }
-        } else {
-            Spacer(Modifier.weight(1f))
-            Text(
-                text = _formatTime(positionMs),
-                style = MaterialTheme.typography.titleMedium,
-                color = Color.White
-            )
-        }
-    }
-}
-
 @Composable
 private fun NowPlayingContent(viewModel: MainViewModel) {
     val track by viewModel.trackInfo.collectAsState()
@@ -714,8 +901,8 @@ private fun NowPlayingContent(viewModel: MainViewModel) {
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
-                Text(_formatTime(positionMs), style = MaterialTheme.typography.labelSmall)
-                Text(_formatTime(durationMs), style = MaterialTheme.typography.labelSmall)
+                Text(formatVideoTime(positionMs), style = MaterialTheme.typography.labelSmall)
+                Text(formatVideoTime(durationMs), style = MaterialTheme.typography.labelSmall)
             }
         }
 
@@ -746,13 +933,7 @@ private fun NowPlayingContent(viewModel: MainViewModel) {
     }
 }
 
-private const val VIDEO_OVERLAY_HIDE_MS = 3000L
-
-private fun _formatTime(ms: Long): String {
-    val s = (ms / 1000).toInt()
-    return if (s >= 3600) "%d:%02d:%02d".format(s / 3600, (s % 3600) / 60, s % 60)
-    else "%d:%02d".format(s / 60, s % 60)
-}
+private const val VIDEO_OVERLAY_HIDE_MS = 4000L
 
 @Composable
 private fun DebugOverlay(info: DebugInfo, modifier: Modifier = Modifier) {

--- a/app/src/main/kotlin/io/github/jqssun/airplay/ui/PlaybackSpeedSelector.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/ui/PlaybackSpeedSelector.kt
@@ -1,0 +1,218 @@
+package io.github.jqssun.airplay.ui
+
+import android.content.res.Configuration
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.Remove
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import io.github.jqssun.airplay.R
+import kotlin.math.round
+
+// portrait slides up from the bottom, landscape in from the end
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun BoxScope.PlaybackSpeedSelector(
+    show: Boolean,
+    speed: Float,
+    skipSilence: Boolean,
+    onSpeedChange: (Float) -> Unit,
+    onSkipSilenceChange: (Boolean) -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val hapticFeedback = LocalHapticFeedback.current
+    val portrait = LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT
+
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(show) {
+        if (show) focusRequester.requestFocusUntilLanded(attempts = 5)
+    }
+
+    if (show) {
+        BackHandler(onBack = onDismiss)
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .pointerInput(Unit) { detectTapGestures { onDismiss() } }
+        )
+    }
+    AnimatedVisibility(
+        modifier = Modifier.align(if (portrait) Alignment.BottomCenter else Alignment.CenterEnd),
+        visible = show,
+        enter = if (portrait) slideInVertically { it } else slideInHorizontally { it },
+        exit = if (portrait) slideOutVertically { it } else slideOutHorizontally { it },
+    ) {
+        Surface(
+            shape = RoundedCornerShape(16.dp),
+            modifier = modifier.then(
+                if (portrait) Modifier.fillMaxWidth().fillMaxHeight(0.45f)
+                else Modifier.fillMaxWidth(0.45f).fillMaxHeight()
+            ),
+        ) {
+            val endPadding = WindowInsets.safeDrawing.asPaddingValues()
+                .calculateEndPadding(LocalLayoutDirection.current)
+            Column(
+                modifier = Modifier
+                    .focusRequester(focusRequester)
+                    .focusGroup()
+                    .padding(top = 24.dp)
+                    .padding(end = endPadding)
+            ) {
+                Text(
+                    modifier = Modifier.padding(horizontal = 24.dp),
+                    text = stringResource(R.string.select_playback_speed),
+                    style = MaterialTheme.typography.headlineSmall,
+                )
+                Spacer(modifier = Modifier.size(8.dp))
+                Column(
+                    modifier = Modifier
+                        .verticalScroll(rememberScrollState())
+                        .padding(bottom = 24.dp)
+                        .padding(horizontal = 24.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        FilledTonalIconButton(
+                            onClick = { onSpeedChange((speed - STEP).coerceAtLeast(MIN_SPEED)) },
+                            modifier = Modifier.focusRing()
+                        ) {
+                            Icon(Icons.Rounded.Remove, contentDescription = null)
+                        }
+                        Text(
+                            text = (round(speed * 100) / 100).toString(),
+                            style = MaterialTheme.typography.titleMedium,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.weight(1f),
+                        )
+                        FilledTonalIconButton(
+                            onClick = { onSpeedChange((speed + STEP).coerceAtMost(MAX_SPEED)) },
+                            modifier = Modifier.focusRing()
+                        ) {
+                            Icon(Icons.Rounded.Add, contentDescription = null)
+                        }
+                    }
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Slider(
+                            value = speed,
+                            valueRange = MIN_SPEED..MAX_SPEED,
+                            steps = ((MAX_SPEED - MIN_SPEED) / STEP).toInt() - 1,
+                            onValueChange = {
+                                hapticFeedback.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                                onSpeedChange(it)
+                            },
+                            modifier = Modifier.weight(1f).focusRing(MaterialTheme.shapes.small),
+                        )
+                        IconButton(onClick = { onSpeedChange(1f) }, modifier = Modifier.focusRing()) {
+                            Icon(Icons.Rounded.Refresh, contentDescription = stringResource(R.string.cd_reset_speed))
+                        }
+                    }
+                    FlowRow(
+                        maxItemsInEachRow = 5,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        PRESETS.forEach { preset ->
+                            Box(
+                                modifier = Modifier
+                                    .clip(CircleShape)
+                                    .focusRing(CircleShape)
+                                    .border(width = 1.dp, color = LocalContentColor.current, shape = CircleShape)
+                                    .clickable { onSpeedChange(preset) }
+                                    .padding(8.dp)
+                                    .weight(1f),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                Text(
+                                    text = preset.toString(),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.primary,
+                                )
+                            }
+                        }
+                    }
+                    Row(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(4.dp))
+                            .focusRing(RoundedCornerShape(4.dp))
+                            .toggleable(value = skipSilence, onValueChange = onSkipSilenceChange)
+                            .fillMaxWidth()
+                            .padding(8.dp)
+                            .semantics(mergeDescendants = true) {},
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    ) {
+                        Text(
+                            text = stringResource(R.string.skip_silence),
+                            style = MaterialTheme.typography.bodyLarge,
+                            modifier = Modifier.weight(1f),
+                        )
+                        Switch(checked = skipSilence, onCheckedChange = null)
+                    }
+                }
+            }
+        }
+    }
+}
+
+private const val MIN_SPEED = 0.2f
+private const val MAX_SPEED = 4f
+private const val STEP = 0.1f
+private val PRESETS = listOf(0.2f, 0.5f, 0.75f, 1.0f, 1.5f, 2.0f, 2.5f, 3.0f, 3.5f, 4.0f)

--- a/app/src/main/kotlin/io/github/jqssun/airplay/ui/TvFocus.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/ui/TvFocus.kt
@@ -1,0 +1,47 @@
+package io.github.jqssun.airplay.ui
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+inline fun Modifier.thenIf(condition: Boolean, block: Modifier.() -> Modifier): Modifier =
+    if (condition) block() else this
+
+@Composable
+fun Modifier.focusRing(
+    shape: Shape = CircleShape,
+    color: Color = MaterialTheme.colorScheme.primary,
+    width: Dp = 3.dp,
+): Modifier {
+    var focused by remember { mutableStateOf(false) }
+    return this
+        .onFocusChanged { focused = it.hasFocus }
+        .thenIf(focused) { border(width = width, color = color, shape = shape) }
+}
+
+// focus can only land once the target is composed; retry across frames
+suspend fun FocusRequester.requestFocusUntilLanded(
+    attempts: Int = 10,
+    isFocused: (() -> Boolean)? = null,
+): Boolean {
+    repeat(attempts) {
+        val requested = runCatching { requestFocus() }.isSuccess
+        if (isFocused?.invoke() ?: requested) return true
+        withFrameNanos { }
+        if (isFocused?.invoke() == true) return true
+    }
+    return false
+}

--- a/app/src/main/kotlin/io/github/jqssun/airplay/ui/VideoControls.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/ui/VideoControls.kt
@@ -1,0 +1,582 @@
+package io.github.jqssun.airplay.ui
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.displayCutout
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.AspectRatio
+import androidx.compose.material.icons.rounded.ContentCopy
+import androidx.compose.material.icons.rounded.CropLandscape
+import androidx.compose.material.icons.rounded.Download
+import androidx.compose.material.icons.rounded.FastForward
+import androidx.compose.material.icons.rounded.FitScreen
+import androidx.compose.material.icons.rounded.Lock
+import androidx.compose.material.icons.rounded.LockOpen
+import androidx.compose.material.icons.rounded.Pause
+import androidx.compose.material.icons.rounded.PhotoSizeSelectActual
+import androidx.compose.material.icons.rounded.PictureInPictureAlt
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.ScreenRotation
+import androidx.compose.material.icons.rounded.Speed
+import androidx.compose.material.ripple.RippleAlpha
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.LocalRippleConfiguration
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RippleConfiguration
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.LocalViewConfiguration
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import io.github.jqssun.airplay.R
+import io.github.jqssun.airplay.ui.gestures.VideoContentScale
+import io.github.jqssun.airplay.viewmodel.MainViewModel
+import kotlin.math.abs
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+
+// white content, strong white ripple; long-press detected via interactions
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PlayerButton(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+    onLongClick: (() -> Unit)? = null,
+    containerColor: Color = Color.Transparent,
+    content: @Composable () -> Unit,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val viewConfiguration = LocalViewConfiguration.current
+    val hapticFeedback = LocalHapticFeedback.current
+
+    LaunchedEffect(interactionSource) {
+        var longPressed = false
+        interactionSource.interactions.collectLatest { interaction ->
+            when (interaction) {
+                is PressInteraction.Press -> {
+                    longPressed = false
+                    delay(viewConfiguration.longPressTimeoutMillis)
+                    onLongClick?.let {
+                        longPressed = true
+                        hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                        it.invoke()
+                    }
+                }
+                is PressInteraction.Release -> if (!longPressed) onClick()
+                else -> Unit
+            }
+        }
+    }
+
+    CompositionLocalProvider(
+        LocalContentColor provides Color.White,
+        LocalRippleConfiguration provides RippleConfiguration(
+            color = Color.White,
+            rippleAlpha = RippleAlpha(
+                draggedAlpha = 0.5f,
+                focusedAlpha = 0.5f,
+                hoveredAlpha = 0.5f,
+                pressedAlpha = 0.5f
+            )
+        )
+    ) {
+        IconButton(
+            onClick = {},
+            modifier = modifier.focusRing(),
+            interactionSource = interactionSource,
+            colors = IconButtonDefaults.iconButtonColors().copy(containerColor = containerColor),
+            content = content,
+        )
+    }
+}
+
+@Composable
+fun PlayPauseButton(playing: Boolean, onClick: () -> Unit, modifier: Modifier = Modifier) {
+    PlayerButton(modifier = modifier.size(64.dp), onClick = onClick) {
+        Icon(
+            imageVector = if (playing) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
+            contentDescription = stringResource(R.string.cd_play_pause),
+            modifier = Modifier.size(48.dp)
+        )
+    }
+}
+
+@Composable
+fun VideoControlsTop(
+    title: String,
+    videoUrl: String?,
+    downloadProgress: Int?,
+    showDownload: Boolean,
+    onBackClick: () -> Unit,
+    onSpeedClick: () -> Unit,
+    onDownloadClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val insets = WindowInsets.systemBars.union(WindowInsets.displayCutout).asPaddingValues()
+    val layoutDirection = LocalLayoutDirection.current
+    val extraTopPadding = if (insets.calculateTopPadding() == 0.dp) 16.dp else 0.dp
+    Row(
+        modifier = modifier
+            .padding(
+                start = insets.calculateStartPadding(layoutDirection),
+                top = insets.calculateTopPadding(),
+                end = insets.calculateEndPadding(layoutDirection),
+            )
+            .padding(horizontal = 8.dp)
+            .padding(bottom = 16.dp)
+            .padding(top = extraTopPadding),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        PlayerButton(onClick = onBackClick) {
+            Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = stringResource(R.string.cd_back))
+        }
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            color = Color.White,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            PlayerButton(onClick = onSpeedClick) {
+                Icon(Icons.Rounded.Speed, contentDescription = stringResource(R.string.select_playback_speed))
+            }
+            if (videoUrl != null) {
+                val clipboard = LocalClipboardManager.current
+                PlayerButton(onClick = { clipboard.setText(AnnotatedString(videoUrl)) }) {
+                    Icon(Icons.Rounded.ContentCopy, contentDescription = stringResource(R.string.cd_copy_url))
+                }
+            }
+            if (showDownload) {
+                PlayerButton(onClick = onDownloadClick) {
+                    when {
+                        downloadProgress == null -> Icon(
+                            Icons.Rounded.Download,
+                            contentDescription = stringResource(R.string.cd_download)
+                        )
+                        downloadProgress < 0 -> CircularProgressIndicator(
+                            color = Color.White,
+                            strokeWidth = 3.dp,
+                            modifier = Modifier.size(24.dp)
+                        )
+                        else -> CircularProgressIndicator(
+                            progress = { downloadProgress / 100f },
+                            color = Color.White,
+                            trackColor = Color.White.copy(alpha = 0.3f),
+                            strokeWidth = 3.dp,
+                            modifier = Modifier.size(24.dp)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun VideoControlsBottom(
+    positionMs: Long,
+    durationMs: Long,
+    contentScale: VideoContentScale,
+    isPipSupported: Boolean,
+    onRotateClick: () -> Unit,
+    onLockClick: () -> Unit,
+    onContentScaleClick: () -> Unit,
+    onPipClick: () -> Unit,
+    onSeek: (Long) -> Unit,
+    onSeekEnd: () -> Unit,
+    modifier: Modifier = Modifier,
+    seekBarModifier: Modifier = Modifier,
+) {
+    val insets = WindowInsets.systemBars.union(WindowInsets.displayCutout).asPaddingValues()
+    val layoutDirection = LocalLayoutDirection.current
+    Column(
+        modifier = modifier
+            .padding(
+                start = insets.calculateStartPadding(layoutDirection),
+                end = insets.calculateEndPadding(layoutDirection),
+                bottom = insets.calculateBottomPadding(),
+            )
+            .padding(horizontal = 8.dp)
+            .padding(top = 16.dp)
+            .padding(bottom = 16.dp.takeIf { insets.calculateBottomPadding() == 0.dp } ?: 0.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            var showRemaining by rememberSaveable { mutableStateOf(false) }
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                ) { showRemaining = !showRemaining },
+            ) {
+                Text(
+                    text = if (showRemaining) "-${formatVideoTime(durationMs - positionMs)}" else formatVideoTime(positionMs),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color.White,
+                )
+                Text(text = " / ", style = MaterialTheme.typography.bodyMedium, color = Color.White)
+                Text(
+                    text = formatVideoTime(durationMs),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color.White,
+                )
+            }
+            Spacer(modifier = Modifier.weight(1f))
+            PlayerButton(modifier = Modifier.size(30.dp), onClick = onRotateClick) {
+                Icon(
+                    Icons.Rounded.ScreenRotation,
+                    contentDescription = stringResource(R.string.cd_rotate),
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+        }
+        PlayerSeekbar(
+            positionMs = positionMs,
+            durationMs = durationMs,
+            onSeek = onSeek,
+            onSeekEnd = onSeekEnd,
+            modifier = seekBarModifier,
+        )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState()),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp, alignment = Alignment.Start),
+        ) {
+            PlayerButton(onClick = onLockClick) {
+                Icon(Icons.Rounded.LockOpen, contentDescription = stringResource(R.string.cd_lock_controls))
+            }
+            PlayerButton(onClick = onContentScaleClick) {
+                Icon(contentScale.icon(), contentDescription = stringResource(contentScale.nameRes()))
+            }
+            if (isPipSupported) {
+                PlayerButton(onClick = onPipClick) {
+                    Icon(Icons.Rounded.PictureInPictureAlt, contentDescription = stringResource(R.string.cd_pip))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun UnlockButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
+    PlayerButton(
+        modifier = modifier,
+        containerColor = Color.Black.copy(0.5f),
+        onClick = onClick,
+    ) {
+        Icon(Icons.Rounded.Lock, contentDescription = stringResource(R.string.cd_unlock_controls))
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun PlayerSeekbar(
+    positionMs: Long,
+    durationMs: Long,
+    onSeek: (Long) -> Unit,
+    onSeekEnd: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var isFocused by remember { mutableStateOf(false) }
+    val thumbSize by animateDpAsState(if (isFocused) 22.dp else 16.dp, label = "thumbSize")
+    CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+        Slider(
+            value = positionMs.toFloat().coerceIn(0f, durationMs.toFloat()),
+            valueRange = 0f..durationMs.toFloat(),
+            onValueChange = { onSeek(it.toLong()) },
+            onValueChangeFinished = onSeekEnd,
+            modifier = modifier
+                .fillMaxWidth()
+                .onFocusChanged { isFocused = it.isFocused }
+                .height(24.dp),
+            thumb = {
+                Box(
+                    modifier = Modifier
+                        .size(thumbSize)
+                        .shadow(4.dp, CircleShape)
+                        .background(Color.White)
+                        .then(
+                            if (isFocused) {
+                                Modifier.border(2.dp, MaterialTheme.colorScheme.primary, CircleShape)
+                            } else Modifier
+                        ),
+                )
+            },
+            track = {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(4.dp)
+                        .clip(MaterialTheme.shapes.extraSmall)
+                        .background(Color.White.copy(alpha = 0.5f))
+                ) {
+                    if (durationMs > 0) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth((positionMs.toFloat() / durationMs).coerceIn(0f, 1f))
+                                .height(4.dp)
+                                .background(MaterialTheme.colorScheme.primary)
+                        )
+                    }
+                }
+            }
+        )
+    }
+}
+
+// sizes the surface per content scale; requiredSize lets crop/100% exceed the container
+@Composable
+fun VideoContentFrame(
+    aspect: Float,
+    videoSizePx: Pair<Int, Int>?,
+    contentScale: VideoContentScale,
+    zoom: Float,
+    modifier: Modifier = Modifier,
+    content: @Composable (Modifier) -> Unit,
+) {
+    BoxWithConstraints(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        val w = maxWidth
+        val h = maxHeight
+        val fit = if (w / h > aspect) Modifier.requiredSize(h * aspect, h) else Modifier.requiredSize(w, w / aspect)
+        val sizeModifier = when (contentScale) {
+            VideoContentScale.BEST_FIT -> fit
+            VideoContentScale.STRETCH -> Modifier.requiredSize(w, h)
+            VideoContentScale.CROP ->
+                if (w / h > aspect) Modifier.requiredSize(w, w / aspect) else Modifier.requiredSize(h * aspect, h)
+            VideoContentScale.HUNDRED_PERCENT -> videoSizePx?.let { (pxW, pxH) ->
+                with(LocalDensity.current) { Modifier.requiredSize(pxW.toDp(), pxH.toDp()) }
+            } ?: fit
+        }
+        content(
+            sizeModifier.graphicsLayer {
+                scaleX = zoom
+                scaleY = zoom
+            }
+        )
+    }
+}
+
+// key decision table: visible controls hand dpad to focus navigation,
+// hidden controls make dpad seek, locked controls only unlock via center
+fun handlePlayerKeyEvent(
+    keyEvent: KeyEvent,
+    controlsVisible: Boolean,
+    controlsLocked: Boolean,
+    isPlayPauseFocused: Boolean,
+    seekIncrementMs: Long,
+    viewModel: MainViewModel,
+    showControls: () -> Unit,
+    unlockControls: () -> Unit,
+    onDpadSeek: (deltaMs: Long) -> Unit,
+): Boolean {
+    if (keyEvent.type != KeyEventType.KeyDown) return false
+    if (controlsLocked) {
+        return when (keyEvent.key) {
+            Key.DirectionCenter, Key.Enter, Key.NumPadEnter -> {
+                if (controlsVisible) unlockControls() else showControls()
+                true
+            }
+            else -> {
+                showControls()
+                false
+            }
+        }
+    }
+
+    return when (keyEvent.key) {
+        Key.MediaPlayPause, Key.Spacebar -> { viewModel.toggleVideoPlayPause(); showControls(); true }
+        Key.MediaPlay -> { viewModel.setVideoPlaying(true); showControls(); true }
+        Key.MediaPause -> { viewModel.setVideoPlaying(false); showControls(); true }
+        Key.MediaFastForward -> { viewModel.seekVideoBy(seekIncrementMs); showControls(); true }
+        Key.MediaRewind -> { viewModel.seekVideoBy(-seekIncrementMs); showControls(); true }
+        Key.MediaStop -> { viewModel.stopVideoPlayback(); true }
+        Key.DirectionCenter, Key.Enter, Key.NumPadEnter -> {
+            when {
+                !controlsVisible -> {
+                    showControls()
+                    true
+                }
+                isPlayPauseFocused -> {
+                    viewModel.toggleVideoPlayPause()
+                    showControls()
+                    true
+                }
+                else -> false
+            }
+        }
+        Key.DirectionLeft -> {
+            if (!controlsVisible) {
+                viewModel.seekVideoBy(-seekIncrementMs)
+                onDpadSeek(-seekIncrementMs)
+                true
+            } else {
+                showControls()
+                false
+            }
+        }
+        Key.DirectionRight -> {
+            if (!controlsVisible) {
+                viewModel.seekVideoBy(seekIncrementMs)
+                onDpadSeek(seekIncrementMs)
+                true
+            } else {
+                showControls()
+                false
+            }
+        }
+        Key.DirectionUp, Key.DirectionDown -> {
+            showControls()
+            !controlsVisible
+        }
+        else -> false
+    }
+}
+
+// cumulative amount skipped by repeated dpad seeks while controls are hidden
+@Composable
+fun BoxScope.DpadSeekIndicator(
+    visible: Boolean,
+    offsetMs: Long,
+    positionMs: Long,
+) {
+    AnimatedVisibility(
+        modifier = Modifier.align(Alignment.Center),
+        visible = visible,
+        enter = fadeIn(),
+        exit = fadeOut(),
+    ) {
+        Surface(
+            shape = RoundedCornerShape(16.dp),
+            color = Color.Black.copy(alpha = 0.6f),
+        ) {
+            Row(
+                modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.FastForward,
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier
+                        .size(28.dp)
+                        .rotate(if (offsetMs < 0) 180f else 0f),
+                )
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = (if (offsetMs >= 0) "+" else "-") +
+                            stringResource(R.string.seconds_short, abs(offsetMs) / 1000),
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White,
+                    )
+                    Text(
+                        text = formatVideoTime(positionMs),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = Color.White.copy(alpha = 0.8f),
+                    )
+                }
+            }
+        }
+    }
+}
+
+fun VideoContentScale.nameRes(): Int = when (this) {
+    VideoContentScale.BEST_FIT -> R.string.scale_best_fit
+    VideoContentScale.STRETCH -> R.string.scale_stretch
+    VideoContentScale.CROP -> R.string.scale_crop
+    VideoContentScale.HUNDRED_PERCENT -> R.string.scale_hundred_percent
+}
+
+fun VideoContentScale.icon(): ImageVector = when (this) {
+    VideoContentScale.BEST_FIT -> Icons.Rounded.FitScreen
+    VideoContentScale.STRETCH -> Icons.Rounded.AspectRatio
+    VideoContentScale.CROP -> Icons.Rounded.CropLandscape
+    VideoContentScale.HUNDRED_PERCENT -> Icons.Rounded.PhotoSizeSelectActual
+}
+
+internal fun formatVideoTime(ms: Long): String {
+    val s = (ms / 1000).toInt().coerceAtLeast(0)
+    return if (s >= 3600) "%d:%02d:%02d".format(s / 3600, (s % 3600) / 60, s % 60)
+    else "%d:%02d".format(s / 60, s % 60)
+}

--- a/app/src/main/kotlin/io/github/jqssun/airplay/ui/VideoSurfaceView.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/ui/VideoSurfaceView.kt
@@ -16,6 +16,8 @@ fun VideoSurfaceView(
     onSurfaceAvailable: (Surface) -> Unit,
     onSurfaceDestroyed: (Surface) -> Unit,
     aspectRatio: Float = 16f / 9f,
+    // false = caller sizes the surface (content-scale modes)
+    applyAspectRatio: Boolean = true,
     modifier: Modifier = Modifier
 ) {
     val callbacks = remember {
@@ -38,8 +40,12 @@ fun VideoSurfaceView(
                 it.holder.addCallback(callbacks)
             }
         },
-        modifier = modifier
-            .aspectRatio(aspectRatio, matchHeightConstraintsFirst = aspectRatio < 1f)
-            .fillMaxSize()
+        modifier = if (applyAspectRatio) {
+            modifier
+                .aspectRatio(aspectRatio, matchHeightConstraintsFirst = aspectRatio < 1f)
+                .fillMaxSize()
+        } else {
+            modifier
+        }
     )
 }

--- a/app/src/main/kotlin/io/github/jqssun/airplay/ui/gestures/GestureDetectors.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/ui/gestures/GestureDetectors.kt
@@ -1,0 +1,102 @@
+package io.github.jqssun.airplay.ui.gestures
+
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitHorizontalTouchSlopOrCancellation
+import androidx.compose.foundation.gestures.awaitVerticalTouchSlopOrCancellation
+import androidx.compose.foundation.gestures.calculateCentroidSize
+import androidx.compose.foundation.gestures.calculatePan
+import androidx.compose.foundation.gestures.calculateZoom
+import androidx.compose.foundation.gestures.horizontalDrag
+import androidx.compose.foundation.gestures.verticalDrag
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.PointerInputScope
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.input.pointer.positionChanged
+import kotlin.math.abs
+
+suspend fun PointerInputScope.detectHorizontalDragGestures(
+    onDragStart: (Offset) -> Unit,
+    onDragEnd: () -> Unit,
+    onHorizontalDrag: (change: PointerInputChange, dragAmount: Float) -> Unit,
+) {
+    awaitEachGesture {
+        val down = awaitFirstDown(requireUnconsumed = false)
+        var overSlop = 0f
+        val drag = awaitHorizontalTouchSlopOrCancellation(down.id) { change, over ->
+            change.consume()
+            overSlop = over
+        }
+        if (drag != null && currentEvent.changes.count { it.pressed } == 1) {
+            onDragStart(drag.position)
+            onHorizontalDrag(drag, overSlop)
+            horizontalDrag(drag.id) {
+                onHorizontalDrag(it, it.positionChange().x)
+                it.consume()
+            }
+            onDragEnd()
+        }
+    }
+}
+
+suspend fun PointerInputScope.detectVerticalDragGestures(
+    onDragStart: (Offset) -> Unit,
+    onDragEnd: () -> Unit,
+    onVerticalDrag: (change: PointerInputChange, dragAmount: Float) -> Unit,
+) {
+    awaitEachGesture {
+        val down = awaitFirstDown(requireUnconsumed = false)
+        var overSlop = 0f
+        val drag = awaitVerticalTouchSlopOrCancellation(down.id) { change, over ->
+            change.consume()
+            overSlop = over
+        }
+        if (drag != null && currentEvent.changes.count { it.pressed } == 1) {
+            onDragStart(drag.position)
+            onVerticalDrag(drag, overSlop)
+            verticalDrag(drag.id) {
+                onVerticalDrag(it, it.positionChange().y)
+                it.consume()
+            }
+            onDragEnd()
+        }
+    }
+}
+
+// two-pointer pinch; bails out while a single-pointer drag owns the gesture
+suspend fun PointerInputScope.detectZoomGestures(
+    onZoom: (zoomChange: Float) -> Unit,
+    onZoomEnd: () -> Unit,
+) {
+    awaitEachGesture {
+        var zoom = 1f
+        var pan = Offset.Zero
+        var pastTouchSlop = false
+        var started = false
+        val touchSlop = viewConfiguration.touchSlop
+        awaitFirstDown(requireUnconsumed = false)
+        do {
+            val event = awaitPointerEvent()
+            val canceled = event.changes.any { it.isConsumed } ||
+                event.changes.count { it.pressed } != 2
+            if (!canceled) {
+                started = true
+                val zoomChange = event.calculateZoom()
+                if (!pastTouchSlop) {
+                    zoom *= zoomChange
+                    pan += event.calculatePan()
+                    val centroidSize = event.calculateCentroidSize(useCurrent = false)
+                    if (abs(1 - zoom) * centroidSize > touchSlop || pan.getDistance() > touchSlop) {
+                        pastTouchSlop = true
+                    }
+                }
+                if (pastTouchSlop) {
+                    if (zoomChange != 1f) onZoom(zoomChange)
+                    event.changes.forEach { if (it.positionChanged()) it.consume() }
+                }
+            }
+        } while (!canceled && event.changes.any { it.pressed })
+        if (started) onZoomEnd()
+    }
+}

--- a/app/src/main/kotlin/io/github/jqssun/airplay/ui/gestures/GestureStates.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/ui/gestures/GestureStates.kt
@@ -1,0 +1,307 @@
+package io.github.jqssun.airplay.ui.gestures
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.media.AudioDeviceInfo
+import android.media.AudioManager
+import android.provider.Settings
+import android.view.Window
+import android.view.WindowManager
+import androidx.compose.runtime.DisposableEffectResult
+import androidx.compose.runtime.DisposableEffectScope
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.unit.IntSize
+import io.github.jqssun.airplay.viewmodel.MainViewModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+// zones: left 35% = back, right 35% = forward, middle = play/pause
+@Stable
+class TapGestureState(
+    private val viewModel: MainViewModel,
+    private val scope: CoroutineScope,
+) {
+    // accumulated double-tap seek shown by the indicator; sign is the direction
+    var seekMillis by mutableLongStateOf(0L)
+        private set
+    val interactionSource = MutableInteractionSource()
+    private var resetJob: Job? = null
+
+    fun handleDoubleTap(offset: Offset, size: IntSize) {
+        if (viewModel.videoDurationMs.value <= 0) return
+        val zone = offset.x / size.width
+        when {
+            zone < 0.35f -> _step(-SEEK_INCREMENT_MS, offset)
+            zone > 0.65f -> _step(SEEK_INCREMENT_MS, offset)
+            else -> viewModel.toggleVideoPlayPause(showOverlay = false)
+        }
+    }
+
+    private fun _step(deltaMs: Long, offset: Offset) {
+        // direction flip restarts the accumulator
+        if (seekMillis != 0L && (seekMillis > 0) != (deltaMs > 0)) seekMillis = 0
+        seekMillis += deltaMs
+        viewModel.seekVideoBy(deltaMs)
+        interactionSource.tryEmit(PressInteraction.Press(offset))
+        resetJob?.cancel()
+        resetJob = scope.launch {
+            delay(INDICATOR_TIMEOUT_MS)
+            seekMillis = 0
+        }
+    }
+
+    companion object {
+        const val SEEK_INCREMENT_MS = 10_000L
+        private const val INDICATOR_TIMEOUT_MS = 750L
+    }
+}
+
+// shared by the horizontal drag gesture and the seekbar; 50ms per dragged px
+@Stable
+class SeekGestureState(private val viewModel: MainViewModel) {
+    var startPositionMs: Long? by mutableStateOf(null)
+        private set
+    var targetPositionMs: Long? by mutableStateOf(null)
+        private set
+    private var startX = 0f
+
+    val seekAmountMs: Long?
+        get() {
+            val start = startPositionMs ?: return null
+            return (targetPositionMs ?: return null) - start
+        }
+
+    fun onDragStart(offset: Offset) {
+        if (viewModel.videoDurationMs.value <= 0) return
+        startX = offset.x
+        _begin()
+    }
+
+    fun onDrag(change: PointerInputChange, dragAmount: Float) {
+        val start = startPositionMs ?: return
+        val duration = viewModel.videoDurationMs.value
+        if (duration <= 0) return
+        val position = viewModel.videoPositionMs.value
+        if (position <= 0 && dragAmount < 0) return
+        if (position >= duration && dragAmount > 0) return
+        _seekTo(start + ((change.position.x - startX) * SEEK_MS_PER_PX).toLong())
+    }
+
+    // seekbar entry point
+    fun onSeek(positionMs: Long) {
+        if (viewModel.videoDurationMs.value <= 0) return
+        if (startPositionMs == null) _begin()
+        _seekTo(positionMs)
+    }
+
+    fun onSeekEnd() {
+        if (startPositionMs == null) return
+        startPositionMs = null
+        targetPositionMs = null
+        viewModel.endVideoScrub()
+    }
+
+    private fun _begin() {
+        startPositionMs = viewModel.videoScrubPositionMs.value ?: viewModel.videoPositionMs.value
+        viewModel.startVideoScrub()
+    }
+
+    private fun _seekTo(positionMs: Long) {
+        val target = positionMs.coerceIn(0L, viewModel.videoDurationMs.value)
+        targetPositionMs = target
+        viewModel.scrubVideoTo(target)
+    }
+
+    companion object {
+        private const val SEEK_MS_PER_PX = 50f
+    }
+}
+
+@Stable
+class VolumeState(private val context: Context) {
+    private val audioManager = context.getSystemService(AudioManager::class.java)
+    private val maxVolume = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
+
+    var percentage by mutableIntStateOf(0)
+        private set
+
+    fun sync() {
+        percentage = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC) * 100 / maxVolume
+    }
+
+    fun update(newPercentage: Int) {
+        percentage = newPercentage.coerceIn(0, 100)
+        // surface the system panel when a headset is connected
+        val flags = if (_isHeadsetOn()) AudioManager.FLAG_SHOW_UI else 0
+        audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, percentage * maxVolume / 100, flags)
+    }
+
+    // keeps the indicator in sync with volume-key presses during a gesture
+    fun handleLifecycle(scope: DisposableEffectScope): DisposableEffectResult = with(scope) {
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(ctx: Context, intent: Intent) {
+                if (intent.action == VOLUME_CHANGED_ACTION) sync()
+            }
+        }
+        context.registerReceiver(receiver, IntentFilter(VOLUME_CHANGED_ACTION))
+        onDispose { context.unregisterReceiver(receiver) }
+    }
+
+    private fun _isHeadsetOn(): Boolean =
+        audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS).any { device ->
+            device.type == AudioDeviceInfo.TYPE_WIRED_HEADSET ||
+                device.type == AudioDeviceInfo.TYPE_WIRED_HEADPHONES ||
+                device.type == AudioDeviceInfo.TYPE_BLUETOOTH_A2DP ||
+                device.type == AudioDeviceInfo.TYPE_BLUETOOTH_SCO ||
+                device.type == AudioDeviceInfo.TYPE_USB_HEADSET
+        }
+
+    companion object {
+        private const val VOLUME_CHANGED_ACTION = "android.media.VOLUME_CHANGED_ACTION"
+    }
+}
+
+@Stable
+class BrightnessState(private val window: Window) {
+    var percentage by mutableIntStateOf(_current())
+        private set
+
+    // window override when set, else the system brightness
+    private fun _current(): Int {
+        val b = window.attributes.screenBrightness
+        val brightness = if (b in 0f..1f) b else {
+            Settings.System.getFloat(window.context.contentResolver, Settings.System.SCREEN_BRIGHTNESS, 127.5f) / 255f
+        }
+        return (brightness * 100).toInt()
+    }
+
+    fun update(newPercentage: Int) {
+        percentage = newPercentage.coerceIn(0, 100)
+        window.attributes = window.attributes.apply { screenBrightness = percentage / 100f }
+    }
+
+    // single-activity app: the override must not outlive the video screen
+    fun clearOverride() {
+        window.attributes = window.attributes.apply {
+            screenBrightness = WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE
+        }
+    }
+}
+
+enum class VerticalGesture { VOLUME, BRIGHTNESS }
+
+// left half = brightness, right half = volume
+@Stable
+class VolumeAndBrightnessGestureState(
+    private val volumeState: VolumeState,
+    private val brightnessState: BrightnessState?,
+    private val scope: CoroutineScope,
+) {
+    var activeGesture: VerticalGesture? by mutableStateOf(null)
+        private set
+    private var startY = 0f
+    private var startVolume = 0
+    private var startBrightness = 0
+    private var hideJob: Job? = null
+
+    fun onDragStart(offset: Offset, size: IntSize) {
+        hideJob?.cancel()
+        activeGesture = if (offset.x < size.width / 2) {
+            VerticalGesture.BRIGHTNESS.takeIf { brightnessState != null }
+        } else {
+            VerticalGesture.VOLUME
+        }
+        startY = offset.y
+        volumeState.sync()
+        startVolume = volumeState.percentage
+        startBrightness = brightnessState?.percentage ?: 0
+    }
+
+    fun onDrag(change: PointerInputChange, dragAmount: Float) {
+        val delta = ((startY - change.position.y) * SENSITIVITY).toInt()
+        when (activeGesture ?: return) {
+            VerticalGesture.VOLUME -> volumeState.update(startVolume + delta)
+            VerticalGesture.BRIGHTNESS -> brightnessState?.update(startBrightness + delta)
+        }
+    }
+
+    fun onDragEnd() {
+        hideJob?.cancel()
+        hideJob = scope.launch {
+            delay(INDICATOR_TIMEOUT_MS)
+            activeGesture = null
+        }
+    }
+
+    companion object {
+        // sensitivity 0.5, applied as sensitivity/10 percent per px
+        private const val SENSITIVITY = 0.05f
+        private const val INDICATOR_TIMEOUT_MS = 1_000L
+    }
+}
+
+enum class VideoContentScale { BEST_FIT, STRETCH, CROP, HUNDRED_PERCENT }
+
+@Stable
+class ZoomState(
+    private val viewModel: MainViewModel,
+    private val scope: CoroutineScope,
+) {
+    var zoom by mutableFloatStateOf(1f)
+        private set
+    var isZooming by mutableStateOf(false)
+        private set
+    var contentScale by mutableStateOf(VideoContentScale.BEST_FIT)
+        private set
+    var showContentScaleIndicator by mutableStateOf(false)
+        private set
+    private var indicatorJob: Job? = null
+
+    fun onZoom(zoomChange: Float) {
+        // zoom is disabled until the timeline is established
+        if (viewModel.videoDurationMs.value <= 0) return
+        isZooming = true
+        zoom = (zoom * zoomChange).coerceIn(MIN_ZOOM, MAX_ZOOM)
+    }
+
+    fun onZoomEnd() {
+        isZooming = false
+    }
+
+    fun switchToNextContentScale() {
+        contentScale = VideoContentScale.entries[(contentScale.ordinal + 1) % VideoContentScale.entries.size]
+        zoom = 1f
+        indicatorJob?.cancel()
+        showContentScaleIndicator = true
+        indicatorJob = scope.launch {
+            delay(CONTENT_SCALE_INDICATOR_MS)
+            showContentScaleIndicator = false
+        }
+    }
+
+    fun reset() {
+        zoom = 1f
+        isZooming = false
+        contentScale = VideoContentScale.BEST_FIT
+    }
+
+    companion object {
+        private const val MIN_ZOOM = 0.25f
+        private const val MAX_ZOOM = 4f
+        private const val CONTENT_SCALE_INDICATOR_MS = 1_000L
+    }
+}

--- a/app/src/main/kotlin/io/github/jqssun/airplay/ui/gestures/GestureUi.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/ui/gestures/GestureUi.kt
@@ -1,0 +1,235 @@
+package io.github.jqssun.airplay.ui.gestures
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.indication
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import io.github.jqssun.airplay.R
+
+@Composable
+fun VideoPlayerGestures(
+    enabled: Boolean,
+    locked: Boolean,
+    onTap: () -> Unit,
+    tapGestureState: TapGestureState,
+    seekGestureState: SeekGestureState,
+    volumeAndBrightnessGestureState: VolumeAndBrightnessGestureState,
+    zoomState: ZoomState,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .pointerInput(enabled, locked) {
+                detectTapGestures(
+                    onTap = {
+                        // taps between double-tap seeks keep accumulating, not toggling controls
+                        if (tapGestureState.seekMillis != 0L) return@detectTapGestures
+                        onTap()
+                    },
+                    onDoubleTap = {
+                        if (enabled && !locked) tapGestureState.handleDoubleTap(offset = it, size = size)
+                    },
+                )
+            }
+            .pointerInput(enabled, locked) {
+                if (!enabled || locked) return@pointerInput
+                detectHorizontalDragGestures(
+                    onDragStart = seekGestureState::onDragStart,
+                    onDragEnd = seekGestureState::onSeekEnd,
+                    onHorizontalDrag = seekGestureState::onDrag,
+                )
+            }
+            .pointerInput(enabled, locked) {
+                if (!enabled || locked) return@pointerInput
+                detectVerticalDragGestures(
+                    onDragStart = { volumeAndBrightnessGestureState.onDragStart(it, size) },
+                    onDragEnd = volumeAndBrightnessGestureState::onDragEnd,
+                    onVerticalDrag = volumeAndBrightnessGestureState::onDrag,
+                )
+            }
+            .pointerInput(enabled, locked) {
+                if (!enabled || locked) return@pointerInput
+                detectZoomGestures(
+                    onZoom = zoomState::onZoom,
+                    onZoomEnd = zoomState::onZoomEnd,
+                )
+            },
+    )
+}
+
+@Composable
+fun DoubleTapIndicator(tapGestureState: TapGestureState, modifier: Modifier = Modifier) {
+    if (tapGestureState.seekMillis == 0L) return
+    val forward = tapGestureState.seekMillis > 0
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = if (forward) Alignment.CenterEnd else Alignment.CenterStart,
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxHeight()
+                .fillMaxWidth(fraction = 0.35f)
+                .clip(if (forward) RightSideOvalShape else LeftSideOvalShape)
+                .background(Color.White.copy(0.2f))
+                .indication(tapGestureState.interactionSource, ripple()),
+            contentAlignment = Alignment.Center,
+        ) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                SeekTriangles(forward = forward)
+                Text(
+                    text = stringResource(R.string.gesture_seek_seconds, tapGestureState.seekMillis / 1000),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = Color.White,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SeekTriangles(forward: Boolean, modifier: Modifier = Modifier) {
+    val alphas = remember { List(3) { Animatable(0f) } }
+    LaunchedEffect(Unit) {
+        val spec = tween<Float>(150)
+        while (true) {
+            alphas.forEach { it.animateTo(1f, spec) }
+            alphas.forEach { it.animateTo(0f, spec) }
+        }
+    }
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier.rotate(if (forward) 0f else 180f),
+    ) {
+        alphas.forEach { alpha ->
+            Icon(
+                imageVector = Icons.Rounded.PlayArrow,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp).graphicsLayer { this.alpha = alpha.value },
+                tint = Color.White,
+            )
+        }
+    }
+}
+
+private val RightSideOvalShape = object : Shape {
+    override fun createOutline(size: Size, layoutDirection: LayoutDirection, density: Density): Outline {
+        val path = Path().apply {
+            moveTo(size.width, size.height)
+            lineTo(size.width, 0f)
+            lineTo(size.width * 0.1f, 0f)
+            cubicTo(size.width * 0.1f, 0f, -size.width * 0.1f, size.height / 2, size.width * 0.1f, size.height)
+            close()
+        }
+        return Outline.Generic(path)
+    }
+}
+
+private val LeftSideOvalShape = object : Shape {
+    override fun createOutline(size: Size, layoutDirection: LayoutDirection, density: Density): Outline {
+        val path = Path().apply {
+            moveTo(0f, 0f)
+            lineTo(size.width * 0.9f, 0f)
+            cubicTo(size.width * 0.9f, 0f, size.width * 1.1f, size.height / 2, size.width * 0.9f, size.height)
+            lineTo(0f, size.height)
+            close()
+        }
+        return Outline.Generic(path)
+    }
+}
+
+@Composable
+fun VerticalProgressIndicator(
+    value: Int,
+    icon: ImageVector,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .heightIn(max = 250.dp)
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.background)
+            .padding(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Box(modifier = Modifier.size(BAR_WIDTH), contentAlignment = Alignment.Center) {
+            Text(
+                text = value.toString(),
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onBackground,
+            )
+        }
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .width(BAR_WIDTH)
+                .clip(MaterialTheme.shapes.medium)
+                .background(MaterialTheme.colorScheme.surfaceVariant),
+            contentAlignment = Alignment.BottomCenter,
+        ) {
+            Box(
+                modifier = Modifier
+                    .width(BAR_WIDTH)
+                    .fillMaxHeight(value.coerceIn(0, 100) / 100f)
+                    .background(MaterialTheme.colorScheme.primary),
+            )
+        }
+        Box(modifier = Modifier.size(BAR_WIDTH), contentAlignment = Alignment.Center) {
+            Icon(imageVector = icon, contentDescription = null, tint = MaterialTheme.colorScheme.onBackground)
+        }
+    }
+}
+
+@Composable
+fun GestureInfoText(info: String, modifier: Modifier = Modifier) {
+    Text(
+        text = info,
+        style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.Bold),
+        color = Color.White,
+        textAlign = TextAlign.Center,
+        modifier = modifier.fillMaxWidth(),
+    )
+}
+
+private val BAR_WIDTH = 32.dp

--- a/app/src/main/kotlin/io/github/jqssun/airplay/viewmodel/MainViewModel.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/viewmodel/MainViewModel.kt
@@ -188,6 +188,18 @@ class MainViewModel @Inject constructor(app: Application) : AndroidViewModel(app
     private val _videoPlaybackAspect = MutableStateFlow(16f / 9f)
     val videoPlaybackAspect: StateFlow<Float> = _videoPlaybackAspect.asStateFlow()
 
+    private val _videoPlaybackSize = MutableStateFlow<Pair<Int, Int>?>(null)
+    val videoPlaybackSize: StateFlow<Pair<Int, Int>?> = _videoPlaybackSize.asStateFlow()
+
+    private val _videoBuffering = MutableStateFlow(false)
+    val videoBuffering: StateFlow<Boolean> = _videoBuffering.asStateFlow()
+
+    private val _videoTitle = MutableStateFlow("")
+    val videoTitle: StateFlow<String> = _videoTitle.asStateFlow()
+
+    private val _videoLocation = MutableStateFlow<String?>(null)
+    val videoLocation: StateFlow<String?> = _videoLocation.asStateFlow()
+
     // optimistic for instant icon feedback, re-synced from the delayed snapshot
     private val _videoPlaying = MutableStateFlow(true)
     val videoPlaying: StateFlow<Boolean> = _videoPlaying.asStateFlow()
@@ -197,13 +209,18 @@ class MainViewModel @Inject constructor(app: Application) : AndroidViewModel(app
     private val _videoDownloadProgress = MutableStateFlow<Int?>(null)
     val videoDownloadProgress: StateFlow<Int?> = _videoDownloadProgress.asStateFlow()
 
+    // mirror the player's playback parameters; sender /rate commands reset speed to 1
+    private val _videoSpeed = MutableStateFlow(1f)
+    val videoSpeed: StateFlow<Float> = _videoSpeed.asStateFlow()
+    private val _videoSkipSilence = MutableStateFlow(false)
+    val videoSkipSilence: StateFlow<Boolean> = _videoSkipSilence.asStateFlow()
+    private var _videoParamsActionAt = 0L
+
     // non-null while a scrub is in flight; committed once after a debounce
     private val _videoScrubPositionMs = MutableStateFlow<Long?>(null)
     val videoScrubPositionMs: StateFlow<Long?> = _videoScrubPositionMs.asStateFlow()
     private var _scrubJob: Job? = null
     private var _lastVideoPlaySeq = 0L
-    private var _scrubLastStepAt = 0L
-    private var _scrubStepsTaken = 0
 
     private val _mirroringActive = MutableStateFlow(false)
     val mirroringActive: StateFlow<Boolean> = _mirroringActive.asStateFlow()
@@ -372,51 +389,46 @@ class MainViewModel @Inject constructor(app: Application) : AndroidViewModel(app
         service?.clearVideoPlaybackSurface(surface)
     }
 
-    fun toggleVideoPlayPause() = setVideoPlaying(!_videoPlaying.value)
+    fun toggleVideoPlayPause(showOverlay: Boolean = true) = setVideoPlaying(!_videoPlaying.value, showOverlay)
 
-    fun setVideoPlaying(playing: Boolean) {
+    fun setVideoPlaying(playing: Boolean, showOverlay: Boolean = true) {
         // pending session: there is no local media yet, nothing to toggle
         if (!_videoPlaybackActive.value) return
         _videoPlaying.value = playing
         _videoActionAt = SystemClock.elapsedRealtime()
         service?.setVideoPlaying(playing)
-        showVideoOverlay()
+        if (showOverlay) showVideoOverlay()
     }
 
-    // tap jumps one tier-0 step; holds take one throttled step per window, ramping tiers
-    fun scrubVideoBy(direction: Int, repeatCount: Int) {
-        val now = SystemClock.elapsedRealtime()
-        if (repeatCount == 0) {
-            _scrubStepsTaken = 0
-        } else if (now - _scrubLastStepAt < SCRUB_REPEAT_THROTTLE_MS) {
-            return
+    // hold the target until the reported position catches up (hls rebuffer)
+    private suspend fun _holdScrubUntilSettled(target: Long) {
+        val deadline = SystemClock.elapsedRealtime() + SCRUB_SETTLE_TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            delay(SCRUB_SETTLE_POLL_MS)
+            if (abs(_videoPositionMs.value - target) <= SCRUB_SETTLE_EPSILON_MS) break
         }
-        _scrubLastStepAt = now
-        val tier = (_scrubStepsTaken / SCRUB_RAMP_DWELL_STEPS).coerceAtMost(SCRUB_STEP_TIERS_MS.lastIndex)
-        val step = SCRUB_STEP_TIERS_MS[tier]
-        _scrubStepsTaken++
-        val from = _videoScrubPositionMs.value ?: _videoPositionMs.value
-        var target = (from + direction * step).coerceAtLeast(0L)
-        val duration = _videoDurationMs.value
-        if (duration > 0) target = target.coerceAtMost(duration)
-        _videoScrubPositionMs.value = target
-        showVideoOverlay()
-        _scheduleScrubCommit()
+        _videoScrubPositionMs.value = null
     }
 
-    private fun _scheduleScrubCommit() {
+    // drag-seek: live seeks under scrubbing mode, settle-hold on release
+    fun startVideoScrub() {
+        _scrubJob?.cancel()
+        service?.setVideoScrubbing(true)
+    }
+
+    fun scrubVideoTo(positionMs: Long) {
+        val duration = _videoDurationMs.value
+        if (duration <= 0) return
+        val target = positionMs.coerceIn(0L, duration)
+        _videoScrubPositionMs.value = target
+        service?.seekVideoTo(target)
+    }
+
+    fun endVideoScrub() {
+        service?.setVideoScrubbing(false)
         _scrubJob?.cancel()
         _scrubJob = viewModelScope.launch {
-            delay(SCRUB_COMMIT_DEBOUNCE_MS)
-            val target = _videoScrubPositionMs.value ?: return@launch
-            service?.seekVideoTo(target)
-            // hold the target until the reported position catches up (hls rebuffer)
-            val deadline = SystemClock.elapsedRealtime() + SCRUB_SETTLE_TIMEOUT_MS
-            while (SystemClock.elapsedRealtime() < deadline) {
-                delay(SCRUB_SETTLE_POLL_MS)
-                if (abs(_videoPositionMs.value - target) <= SCRUB_SETTLE_EPSILON_MS) break
-            }
-            _videoScrubPositionMs.value = null
+            _holdScrubUntilSettled(_videoScrubPositionMs.value ?: return@launch)
         }
     }
 
@@ -426,6 +438,23 @@ class MainViewModel @Inject constructor(app: Application) : AndroidViewModel(app
 
     fun stopVideoPlayback() {
         service?.stopVideoPlayback()
+    }
+
+    fun setVideoSpeed(speed: Float) {
+        val value = speed.coerceIn(0.2f, 4f)
+        _videoSpeed.value = value
+        _videoParamsActionAt = SystemClock.elapsedRealtime()
+        service?.setVideoSpeed(value)
+    }
+
+    fun setVideoSkipSilence(enabled: Boolean) {
+        _videoSkipSilence.value = enabled
+        _videoParamsActionAt = SystemClock.elapsedRealtime()
+        service?.setVideoSkipSilence(enabled)
+    }
+
+    fun seekVideoBy(deltaMs: Long) {
+        service?.seekVideoBy(deltaMs)
     }
 
     fun toggleVideoDownload() {
@@ -462,6 +491,8 @@ class MainViewModel @Inject constructor(app: Application) : AndroidViewModel(app
                 _videoPlaying.value = true
                 _videoActionAt = 0
                 _videoOverlayTick.value = 0
+                _videoSpeed.value = 1f
+                _videoSkipSilence.value = false
                 _scrubJob?.cancel()
                 _videoScrubPositionMs.value = null
             }
@@ -472,7 +503,16 @@ class MainViewModel @Inject constructor(app: Application) : AndroidViewModel(app
                 val info = it.videoPlaybackInfo.value
                 _videoPositionMs.value = info.positionMs
                 _videoDurationMs.value = info.durationMs
+                if (SystemClock.elapsedRealtime() - _videoParamsActionAt > VIDEO_ACTION_SYNC_HOLD_MS) {
+                    _videoSpeed.value = info.speed
+                    _videoSkipSilence.value = info.skipSilence
+                }
+                _videoBuffering.value = info.buffering
                 _videoPlaybackAspect.value = it.videoPlaybackAspect.value
+                _videoPlaybackSize.value = it.videoPlaybackSize.value
+                // stream metadata first, dmap second; senders rarely provide either for video
+                _videoTitle.value = it.videoTitle.value.ifEmpty { it.trackInfo.value.title }
+                _videoLocation.value = it.videoLocation.value
                 // stale snapshots must not overwrite a just-made optimistic action
                 if (SystemClock.elapsedRealtime() - _videoActionAt > VIDEO_ACTION_SYNC_HOLD_MS) {
                     _videoPlaying.value = info.playing
@@ -480,6 +520,7 @@ class MainViewModel @Inject constructor(app: Application) : AndroidViewModel(app
             } else {
                 _videoPositionMs.value = 0
                 _videoDurationMs.value = 0
+                _videoBuffering.value = false
             }
             _mirroringActive.value = it.mirroringActive.value
             _trackInfo.value = it.trackInfo.value
@@ -493,14 +534,6 @@ class MainViewModel @Inject constructor(app: Application) : AndroidViewModel(app
     }
 
     private companion object {
-        // one accepted held-scrub step per window; also the bar's visible cadence
-        const val SCRUB_REPEAT_THROTTLE_MS = 150L
-        // first entry = single-tap jump, shared with the media-session ff/rw step
-        val SCRUB_STEP_TIERS_MS = longArrayOf(
-            AirPlayService.VIDEO_SEEK_STEP_MS, 10_000, 15_000, 20_000, 30_000, 45_000, 60_000
-        )
-        const val SCRUB_RAMP_DWELL_STEPS = 2
-        const val SCRUB_COMMIT_DEBOUNCE_MS = 400L
         // post-commit: show the target until within epsilon, give up after the timeout
         const val SCRUB_SETTLE_POLL_MS = 100L
         const val SCRUB_SETTLE_EPSILON_MS = 2_000L

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,7 +18,7 @@
     <!-- Overview -->
     <string name="server_stopped">Server stopped</string>
     <string name="waiting_for_connection">Waiting for connection...</string>
-    <string name="waiting_for_playback">Please start playing on the sender...</string>
+    <string name="waiting_for_playback">Press start on the sender...</string>
     <string name="error_starting_server">Error starting server</string>
     <string name="connected_count">%d connected</string>
     <string name="error_label">Error</string>
@@ -41,6 +41,24 @@
     <!-- Video download -->
     <string name="download_saved">Saved to %1$s</string>
     <string name="download_failed">Download failed</string>
+
+    <!-- Player gestures -->
+    <string name="gesture_seek_seconds">%1$d seconds</string>
+    <string name="seconds_short">%1$ds</string>
+    <string name="select_playback_speed">Playback speed</string>
+    <string name="cd_reset_speed">Reset speed</string>
+    <string name="skip_silence">Skip silence</string>
+
+    <!-- Player controls -->
+    <string name="cd_back">Back</string>
+    <string name="cd_copy_url">Copy video URL</string>
+    <string name="cd_rotate">Rotate screen</string>
+    <string name="cd_lock_controls">Lock controls</string>
+    <string name="cd_unlock_controls">Unlock controls</string>
+    <string name="scale_best_fit">Best fit</string>
+    <string name="scale_stretch">Stretch</string>
+    <string name="scale_crop">Crop</string>
+    <string name="scale_hundred_percent">100%</string>
 
     <!-- Dialogs -->
     <string name="dialog_pin_title">AirPlay PIN</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.7.3"
+agp = "8.9.2"
 kotlin = "2.1.0"
 ksp = "2.1.0-1.0.29"
 compose-bom = "2024.12.01"
@@ -10,7 +10,7 @@ activity-compose = "1.9.3"
 core-ktx = "1.15.0"
 datastore = "1.1.1"
 coroutines = "1.9.0"
-media3 = "1.5.0"
+media3 = "1.10.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }


### PR DESCRIPTION
Builds on #15 (AirPlay Video). On an Android TV the receiver has its own remote, but during a video session it did nothing — play/pause/seek were phone-only. This routes D-pad and media keys to the local ExoPlayer while an AirPlay Video (HLS) session is active.

**Provenance:** this feature was written by Claude (Anthropic AI) agents working under my direction; I drove the real-device testing and reviewed the code.

### Key mapping (active only while `videoPlaybackActive`)

| Key | Action |
|---|---|
| Play/Pause, D-pad center, Enter | toggle play/pause |
| Play / Pause (discrete keys) | set playing / paused |
| D-pad left, Rewind | seek −10 s (clamped to 0) |
| D-pad right, Fast-forward | seek +15 s (clamped to duration) |
| Stop, Back | tear the video session down locally, same as `POST /stop` |

All are local-only controls, matching the existing tap-to-pause contract: the sender isn't commanded, it self-syncs from its next `GET /playback-info` poll (rate=0 after pause, ready=false after stop).

### How it's routed

- **`MainActivity.dispatchKeyEvent`** intercepts the keys during video sessions. The video surface lives in the activity's Compose tree and nothing in the video screen takes focus, so on Android TV this is where remote KeyEvents actually arrive (Compose `onPreviewKeyEvent` never fires). Matching UP/repeat events are consumed too so nothing leaks into the UI underneath or triggers back-navigation.
- **MediaSession fallback:** the session is now active during video sessions and its transport callbacks (`onPlay`/`onPause`/`onStop`/`onFastForward`/`onRewind`/`onSeekTo`) drive the video player while one is active — **DACP control of audio senders is preserved exactly** when no video session is running (`onSkipToNext`/`onSkipToPrevious` stay DACP-only). Its playback state mirrors the existing 250 ms ExoPlayer snapshot, so system media-button routing (TV remotes, bluetooth) stays on the video session.
- **On-screen feedback:** the tap-to-pause overlay icon is generalised into a transport-feedback event (play/pause/rewind/forward) emitted by the viewmodel, so remote presses get the same brief confirmation as screen taps.

No changes to mirroring or audio paths beyond the guarded MediaSession callbacks above.

### Tested (real device)

Sony KD-49XD8077 (2016 Bravia, Android TV 8), iOS 17/18 senders (iFit and YouTube): play/pause, ±seek and stop from the TV remote all work, phone-side pause/scrub still works and re-syncs, YouTube's FCUP path unaffected.

**Test-scope caveat:** that single TV and those two sender apps are the validated matrix so far — not yet tested on other remotes/devices, other Android TV versions, other sender apps, or for mirroring regressions (the key routing is gated on `videoPlaybackActive`, so mirroring sessions shouldn't see it, but it hasn't been re-verified).

Follow-up in progress locally (not on this branch): a seek-bar overlay showing position/duration during remote seeks — happy to include it here or as a separate PR, whichever you prefer.

Depends on #15; also depends on the UxPlay submodule fix (https://github.com/guslma/UxPlay/pull/1) if the `8635aee` bug-fix commit rides along. Note: until that UxPlay PR merges, this branch's submodule pointer references a commit that only exists in my fork (https://github.com/birax/UxPlay, branch `pr15-tvremote-fixes`), so `git submodule update` will fail against guslma/UxPlay until it lands.
