### PR TITLE
Fix DPAD focus on Now Playing so CENTER pauses music instead of stopping the server

### DIFF
--- a/app/src/main/kotlin/io/github/jqssun/airplay/ui/MainScreen.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/ui/MainScreen.kt
@@ -441,6 +441,15 @@ private fun NowPlayingContent(viewModel: MainViewModel) {
     val durationMs by viewModel.durationMs.collectAsState()
     val playing by viewModel.playing.collectAsState()
 
+    // TV remote: land focus on play/pause when the Now Playing screen appears
+    // (otherwise it stays on the server start/stop button, where DPAD CENTER
+    // would stop the server); LEFT/RIGHT on it skip tracks via DACP directly
+    val tv = isTv()
+    val playPauseFocus = remember { FocusRequester() }
+    LaunchedEffect(Unit) {
+        if (tv) playPauseFocus.requestFocus()
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -535,7 +544,14 @@ private fun NowPlayingContent(viewModel: MainViewModel) {
             }
             FilledIconButton(
                 onClick = { viewModel.dacpPlayPause() },
-                modifier = Modifier.size(56.dp).dpadFocus(CircleShape)
+                modifier = Modifier
+                    .size(56.dp)
+                    .dpadFocus(CircleShape)
+                    .focusRequester(playPauseFocus)
+                    .dpadAdjust(
+                        onLeft = { viewModel.dacpPrev() },
+                        onRight = { viewModel.dacpNext() }
+                    )
             ) {
                 Icon(
                     if (playing) Icons.Default.Pause else Icons.Default.PlayArrow,


### PR DESCRIPTION
Small Android TV fix for audio (AirPlay music) sessions, independent of the AirPlay Video work (#15/#16) — a single commit on `main`.

**Provenance:** this fix was written by Claude (Anthropic AI) agents working under my direction; I drove the real-device testing and reviewed the code.

### Problem

Audio-session transport already reaches the sender over DACP (the media session and notification actions call `DacpController`), but on Android TV the Now Playing screen left DPAD focus sitting on the server start/stop button — so pressing CENTER while music was playing **stopped the whole server** instead of pausing the music.

### Fix

- Focus now lands on the play/pause control when the Now Playing screen appears (gated on `isTv()`), so DPAD CENTER toggles play/pause.
- LEFT/RIGHT on that control send previous/next track via DACP directly — the same `DacpController` commands as the on-screen skip buttons.

### Maintenance notes

- The focus grab is the `playPauseFocus` `FocusRequester` in `NowPlayingContent` (`MainScreen.kt`); it only fires on TV devices, so phone/tablet touch behaviour is unchanged.
- The LEFT/RIGHT mapping reuses the existing `Modifier.dpadAdjust` helper from `ui/Tv.kt`; other keys keep normal focus navigation.

### Tested (real device)

Sony KD-49XD8077 (2016 Bravia, Android TV 8), iOS 17/18 senders: with music AirPlaying, CENTER on the remote now pauses/resumes on the sender, LEFT/RIGHT skip tracks, and the server keeps running throughout.

**Test-scope caveat:** that single TV and its stock remote are the validated matrix so far — not yet tested on other remotes/devices or Android TV versions. Verified manually on-device; no automated tests.
