### PR TITLE
Return to the previous app when casting ends

### DIFF
--- a/app/src/main/kotlin/io/github/jqssun/airplay/MainActivity.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/MainActivity.kt
@@ -10,6 +10,7 @@ import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
+import android.os.SystemClock
 import android.util.Rational
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
@@ -27,8 +28,10 @@ import io.github.jqssun.airplay.ui.MainScreen
 import io.github.jqssun.airplay.ui.theme.AirPlayTheme
 import io.github.jqssun.airplay.viewmodel.MainViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
@@ -40,6 +43,13 @@ class MainActivity : ComponentActivity() {
     private val logCallback: (String) -> Unit = { viewModel.addLog(it) }
     private val pinCallback: (String?) -> Unit = { viewModel.showPin(it) }
 
+    // true while this activity is frontmost only because a session summoned it
+    // (service start carrying EXTRA_SESSION_SUMMON); cleared when the user opens
+    // the app themselves or interacts with it outside a session
+    private var summonedBySession = false
+    private var sessionEndJob: Job? = null
+    private var lastSessionEndedAt = 0L
+
     private val connection = object : ServiceConnection {
         override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
             val svc = (binder as? AirPlayService.LocalBinder)?.service ?: return
@@ -47,11 +57,14 @@ class MainActivity : ComponentActivity() {
             svc.logCallback = logCallback
             svc.pinCallback = pinCallback
             viewModel.bindService(svc)
+            _watchSessionEnd(svc)
             if (viewModel.autoStart.value && svc.serverState.value == AirPlayService.ServerState.STOPPED) {
                 viewModel.startServer()
             }
         }
         override fun onServiceDisconnected(name: ComponentName?) {
+            sessionEndJob?.cancel()
+            sessionEndJob = null
             service = null
             viewModel.unbindService()
         }
@@ -64,6 +77,9 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
+        summonedBySession = savedInstanceState?.getBoolean(STATE_SUMMONED_BY_SESSION)
+            ?: (intent?.getBooleanExtra(EXTRA_SESSION_SUMMON, false) == true)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
             ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
@@ -118,6 +134,68 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    // a summon only counts when it actually brings the activity forward; any other
+    // relaunch (launcher, notification) is the user deliberately opening the app
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        if (intent.getBooleanExtra(EXTRA_SESSION_SUMMON, false)) {
+            if (!lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+                summonedBySession = true
+            }
+        } else {
+            summonedBySession = false
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putBoolean(STATE_SUMMONED_BY_SESSION, summonedBySession)
+    }
+
+    // input while no session is active (and none just ended: the tail of the very
+    // gesture that stopped one must not count) means the user wants to be here
+    override fun onUserInteraction() {
+        super.onUserInteraction()
+        if (!summonedBySession) return
+        val justEnded = SystemClock.elapsedRealtime() - lastSessionEndedAt < SESSION_END_INTERACTION_HOLDOFF_MS
+        if (!_sessionActive(service) && !justEnded) {
+            summonedBySession = false
+        }
+    }
+
+    private fun _sessionActive(svc: AirPlayService?) =
+        svc != null && (svc.videoPlaybackActive.value || svc.mirroringActive.value)
+
+    private fun _watchSessionEnd(svc: AirPlayService) {
+        sessionEndJob?.cancel()
+        sessionEndJob = lifecycleScope.launch {
+            var wasActive = false
+            combine(svc.videoPlaybackActive, svc.mirroringActive) { video, mirror -> video || mirror }
+                .distinctUntilChanged()
+                .collect { active ->
+                    if (!active && wasActive) {
+                        lastSessionEndedAt = SystemClock.elapsedRealtime()
+                        _onSessionEnded(svc)
+                    }
+                    wasActive = active
+                }
+        }
+    }
+
+    private fun _onSessionEnded(svc: AirPlayService) {
+        if (!summonedBySession || !viewModel.returnToPreviousApp.value || isInPip.value) return
+        lifecycleScope.launch {
+            // grace period: a sender switching queue items stops one video and plays
+            // the next on the same connection 1-2s later, which re-summons and must
+            // cancel the step-aside instead of flashing through the previous app
+            delay(SESSION_END_RETURN_GRACE_MS)
+            if (_sessionActive(svc)) return@launch
+            if (!summonedBySession || isInPip.value) return@launch
+            summonedBySession = false
+            moveTaskToBack(true)
+        }
+    }
+
     fun enterPip() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
         enterPictureInPictureMode(_pipParams())
@@ -165,5 +243,16 @@ class MainActivity : ComponentActivity() {
         }
         unbindService(connection)
         super.onDestroy()
+    }
+
+    companion object {
+        const val EXTRA_SESSION_SUMMON = "io.github.jqssun.airplay.extra.SESSION_SUMMON"
+        private const val STATE_SUMMONED_BY_SESSION = "summonedBySession"
+        // long enough that a queue-item switch cancels the pending step-aside,
+        // short enough that a real stop still returns promptly
+        private const val SESSION_END_RETURN_GRACE_MS = 2_500L
+        // ignore "user interaction" this long after a session ends, so the stopping
+        // gesture's tail or impatient presses can't clear summonedBySession
+        private const val SESSION_END_INTERACTION_HOLDOFF_MS = 4_000L
     }
 }

--- a/app/src/main/kotlin/io/github/jqssun/airplay/Prefs.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/Prefs.kt
@@ -45,4 +45,5 @@ object Prefs {
     const val ADVERTISE_VIDEO = "advertise_video"; const val DEF_ADVERTISE_VIDEO = true
     const val ADVERTISE_AUDIO = "advertise_audio"; const val DEF_ADVERTISE_AUDIO = true
     const val LAUNCH_ON_CONNECT = "launch_on_connect"; const val DEF_LAUNCH_ON_CONNECT = true
+    const val RETURN_TO_PREVIOUS_APP = "return_to_previous_app"; const val DEF_RETURN_TO_PREVIOUS_APP = true
 }

--- a/app/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
@@ -622,6 +622,9 @@ class AirPlayService : LifecycleService(), RaopCallbackHandler, LogListener {
         // claim media-button routing for keys that arrive as media-session events
         mediaSession?.isActive = true
         log("AirPlay Video play: $location @ ${startPositionSeconds}s")
+        // re-summon on every play, not only first connect: a queue-item switch can
+        // land after a summoned activity already stepped back to the previous app
+        if (shouldLaunchOnConnect()) launchMainActivity()
     }
 
     override fun onVideoScrub(positionSeconds: Float) {
@@ -1068,9 +1071,10 @@ class AirPlayService : LifecycleService(), RaopCallbackHandler, LogListener {
     }
 
     private fun launchMainActivity() {
-        Handler(Looper.getMainLooper()).post {
+        _mainHandler.post {
             val launchIntent = Intent(this, MainActivity::class.java)
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+                .putExtra(MainActivity.EXTRA_SESSION_SUMMON, true)
             try {
                 startActivity(launchIntent)
             } catch (e: Exception) {

--- a/app/src/main/kotlin/io/github/jqssun/airplay/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/ui/SettingsScreen.kt
@@ -47,6 +47,7 @@ fun SettingsScreen(viewModel: MainViewModel) {
     val advertiseVideo by viewModel.advertiseVideo.collectAsState()
     val advertiseAudio by viewModel.advertiseAudio.collectAsState()
     val launchOnConnect by viewModel.launchOnConnect.collectAsState()
+    val returnToPreviousApp by viewModel.returnToPreviousApp.collectAsState()
     val maxFps by viewModel.maxFps.collectAsState()
     val overscanned by viewModel.overscanned.collectAsState()
     val requirePin by viewModel.requirePin.collectAsState()
@@ -153,6 +154,13 @@ fun SettingsScreen(viewModel: MainViewModel) {
             trailingContent = {
                 Switch(checked = launchOnConnect, onCheckedChange = null)
             }
+        )
+
+        SettingSwitch(
+            title = stringResource(R.string.setting_return_to_previous_app),
+            description = stringResource(R.string.setting_return_to_previous_app_desc),
+            checked = returnToPreviousApp,
+            onCheckedChange = { viewModel.setReturnToPreviousApp(it) }
         )
 
         SectionHeader(stringResource(R.string.section_display))

--- a/app/src/main/kotlin/io/github/jqssun/airplay/viewmodel/MainViewModel.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/viewmodel/MainViewModel.kt
@@ -189,6 +189,9 @@ class MainViewModel @Inject constructor(app: Application) : AndroidViewModel(app
     private val _launchOnConnect = MutableStateFlow(prefs.getBoolean(Prefs.LAUNCH_ON_CONNECT, Prefs.DEF_LAUNCH_ON_CONNECT))
     val launchOnConnect: StateFlow<Boolean> = _launchOnConnect.asStateFlow()
 
+    private val _returnToPreviousApp = MutableStateFlow(prefs.getBoolean(Prefs.RETURN_TO_PREVIOUS_APP, Prefs.DEF_RETURN_TO_PREVIOUS_APP))
+    val returnToPreviousApp: StateFlow<Boolean> = _returnToPreviousApp.asStateFlow()
+
     // debug
     private val _debugEnabled = MutableStateFlow(prefs.getBoolean(Prefs.DEBUG_ENABLED, Prefs.DEF_DEBUG_ENABLED))
     val debugEnabled: StateFlow<Boolean> = _debugEnabled.asStateFlow()
@@ -410,6 +413,7 @@ class MainViewModel @Inject constructor(app: Application) : AndroidViewModel(app
     fun setAdvertiseVideo(v: Boolean) { _advertiseVideo.value = v; prefs.edit().putBoolean(Prefs.ADVERTISE_VIDEO, v).apply(); _applyByServerRestart() }
     fun setAdvertiseAudio(v: Boolean) { _advertiseAudio.value = v; prefs.edit().putBoolean(Prefs.ADVERTISE_AUDIO, v).apply(); _applyByServerRestart() }
     fun setLaunchOnConnect(v: Boolean) { _launchOnConnect.value = v; prefs.edit().putBoolean(Prefs.LAUNCH_ON_CONNECT, v).apply() }
+    fun setReturnToPreviousApp(v: Boolean) { _returnToPreviousApp.value = v; prefs.edit().putBoolean(Prefs.RETURN_TO_PREVIOUS_APP, v).apply() }
     fun setDebugEnabled(v: Boolean) { _debugEnabled.value = v; prefs.edit().putBoolean(Prefs.DEBUG_ENABLED, v).apply() }
     fun setDeveloperOptions(v: Boolean) {
         _developerOptions.value = v

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,6 +113,8 @@
     <string name="setting_launch_on_connect">Open this application on connect</string>
     <string name="setting_launch_on_connect_desc">Show the screen when a client connects</string>
     <string name="setting_launch_on_connect_no_permission">Tap to grant Display over other apps permission</string>
+    <string name="setting_return_to_previous_app">Return to previous app after casting</string>
+    <string name="setting_return_to_previous_app_desc">Leave the screen when a session that opened this application ends</string>
     <string name="setting_resolution">Resolution</string>
     <string name="setting_resolution_desc">Video resolution advertised to clients</string>
     <string name="setting_resolution_placeholder">[W]x[H]</string>


### PR DESCRIPTION
Stacked follow-up to #17 (seek-bar overlay), which stacks on #16 and #15: when a casting session ends, get the TV back to whatever the user was watching instead of stranding them on a frozen last frame or the app's main page.

**Because of the stacking, the "Files changed" tab here includes everything from #15/#16/#17 — the two commits that belong to this PR are best reviewed in the compare view against #17's head: https://github.com/birax/android-airplay-server/compare/video-seekbar...return-to-previous**

**Provenance:** this feature was written by Claude (Anthropic AI) agents working under my direction; I drove the real-device testing and reviewed the code.

### What it does

**Commit 1 — dismiss the video UI on every stop path, then step aside:**

- Frozen-last-frame fix: two stop paths never cleared `videoPlaybackActive` at all — a sender that stops casting without `POST /stop` just kills its HLS source, which ExoPlayer surfaces as a fatal error (or `STATE_ENDED` at end-of-stream) that was merely logged; the released player then sat on the last decoded frame indefinitely. Now `AirPlayVideoPlayer` reports `onPlaybackEnded` on fatal errors and `STATE_ENDED`, all stop paths (`POST /stop`, TEARDOWN, disconnect, local remote stop, player end) funnel through one `endVideoPlayback`, and the viewmodel mirrors `videoPlaybackActive` event-driven from the service flow instead of relying on the 200 ms lifecycle-gated poll, so the surface is dismissed immediately.
- Return to previous app: when the session itself summoned the activity over whatever the user was watching (the service's launch-on-connect start, now marked with an `EXTRA_SESSION_SUMMON` intent extra), ending the session sends the task to the back so Android restores the previous app/input (e.g. an HDMI source) instead of landing on the app's main page. If the user opened the app themselves, nothing changes. Controlled by a new "Return to previous app after casting" setting (EN + pt-BR, default ON; OFF restores the old behaviour exactly).

**Commit 2 — real-device fixes for the summon/return state machine:**

- TV-remote BACK ends the session synchronously on its ACTION_DOWN, so the dangling ACTION_UP used to fall through to `onUserInteraction` and clear the summon flag before the return-to-previous grace could read it. `dispatchKeyEvent` now swallows the rest of any gesture whose DOWN it consumed, and `onUserInteraction` ignores input for a short holdoff after a session ends.
- The service now (re-)summons the activity on EVERY video play (still gated by the "Open this application on connect" setting), not just the first client connection: switching videos in the sender app (stop item A, play item B on the same connection 1–2 s later) could otherwise land after the summoned activity had already stepped back, playing audio into an invisible, surfaceless activity.
- The step-aside grace is 2.5 s so that same-connection follow-up play cancels the pending `moveTaskToBack` — video switching stays seamless instead of flashing through the previous input — while a real stop still returns promptly.

No native/UxPlay changes in this PR.

### Tuning / maintenance notes

All in `MainActivity`'s companion object:

- `SESSION_END_RETURN_GRACE_MS` (2 500) — how long after a session ends before stepping back to the previous app; a follow-up play within it cancels the return (raise if a sender's video switching is slower).
- `SESSION_END_INTERACTION_HOLDOFF_MS` (4 000) — window after a session ends during which user input can't clear the summon flag (guards against remote-key ACTION_UPs and impatient extra presses).
- The whole summon/return state machine logs at INFO under the **`AirPlaySummon`** tag (flag set/cleared with reason, session-end decisions, grace scheduled/fired/aborted) — `adb logcat -s AirPlaySummon` shows every decision on-device.

### Tested (real device)

Sony KD-49XD8077 (2016 Bravia, Android TV 8), iOS senders (iFit and YouTube): TV-remote BACK returns to the previously watched app; ending the cast from the sender (both apps) dismisses the video UI and returns to the previous app; switching videos inside YouTube stays seamless (no flash through the previous input, new video gets a surface); no regressions in play/pause/scrub from either the phone or the TV remote. Commit 2 is the direct result of that on-device session.

**Test-scope caveat:** that single TV and those two sender apps are the validated matrix so far — not yet tested on other devices, other Android TV versions, or other sender apps. Exercised manually on-device; no automated tests.
