### PR TITLE
Robust video session-end detection

### DIFF
--- a/app/src/main/cpp/android_raop_callbacks.c
+++ b/app/src/main/cpp/android_raop_callbacks.c
@@ -42,6 +42,7 @@ void android_callbacks_init(android_callback_ctx_t *ctx, JNIEnv *env, jobject ca
     pthread_mutex_init(&ctx->playback_info_lock, NULL);
     pthread_cond_init(&ctx->play_ready_cond, NULL);
     ctx->play_ready = 0;
+    ctx->last_video_request_ns = 0;
     ctx->playback_position = 0.0;
     /* -1.0 is the video finished sentinel, reserved for _video_stop */
     ctx->playback_duration = 0.0;
@@ -84,6 +85,29 @@ void android_callbacks_destroy(android_callback_ctx_t *ctx, JNIEnv *env) {
     ctx->registered_count = 0;
     pthread_cond_destroy(&ctx->play_ready_cond);
     pthread_mutex_destroy(&ctx->playback_info_lock);
+}
+
+static uint64_t _monotonic_ns(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000000000ull + (uint64_t)ts.tv_nsec;
+}
+
+/* Records that the sender just made a request touching the AirPlay Video session
+   (see last_video_request_ns in the header). Called from httpd threads. */
+static void _touch_video_request(android_callback_ctx_t *ctx) {
+    uint64_t now = _monotonic_ns();
+    pthread_mutex_lock(&ctx->playback_info_lock);
+    ctx->last_video_request_ns = now;
+    pthread_mutex_unlock(&ctx->playback_info_lock);
+}
+
+int64_t android_callbacks_ms_since_video_request(android_callback_ctx_t *ctx) {
+    pthread_mutex_lock(&ctx->playback_info_lock);
+    uint64_t last = ctx->last_video_request_ns;
+    pthread_mutex_unlock(&ctx->playback_info_lock);
+    if (last == 0) return -1;
+    return (int64_t)((_monotonic_ns() - last) / 1000000ull);
 }
 
 void android_callbacks_update_playback_info(android_callback_ctx_t *ctx, double position,
@@ -301,6 +325,7 @@ static bool _check_register(void *cls, const char *pk_str) {
 static void _video_play(void *cls, const char *location, const float start_position) {
     android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
     LOGI("video_play: %s @ %.2fs", location ? location : "(null)", start_position);
+    _touch_video_request(ctx);
     pthread_mutex_lock(&ctx->playback_info_lock);
     ctx->play_ready = 0;
     pthread_mutex_unlock(&ctx->playback_info_lock);
@@ -324,6 +349,7 @@ static void _video_play(void *cls, const char *location, const float start_posit
 
 static void _video_scrub(void *cls, const float position) {
     android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
+    _touch_video_request(ctx);
     JNIEnv *env = _get_env(ctx);
     if (!env) return;
     (*env)->CallVoidMethod(env, ctx->callback_obj, ctx->on_video_scrub, (jfloat)position);
@@ -331,6 +357,7 @@ static void _video_scrub(void *cls, const float position) {
 
 static void _video_rate(void *cls, const float rate) {
     android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
+    _touch_video_request(ctx);
     JNIEnv *env = _get_env(ctx);
     if (!env) return;
     (*env)->CallVoidMethod(env, ctx->callback_obj, ctx->on_video_rate, (jfloat)rate);
@@ -338,6 +365,7 @@ static void _video_rate(void *cls, const float rate) {
 
 static void _video_stop(void *cls) {
     android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
+    _touch_video_request(ctx);
     android_callbacks_update_playback_info(ctx, 0.0, -1.0, 0.0f, 0);
     JNIEnv *env = _get_env(ctx);
     if (!env) return;
@@ -348,6 +376,8 @@ static void _video_stop(void *cls) {
 static void _video_acquire_playback_info(void *cls, playback_info_t *info) {
     android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
     pthread_mutex_lock(&ctx->playback_info_lock);
+    /* the sender's periodic GET /playback-info poll is its liveness heartbeat */
+    ctx->last_video_request_ns = _monotonic_ns();
     info->position = ctx->playback_position;
     info->duration = ctx->playback_duration;
     info->rate = ctx->playback_rate;
@@ -368,6 +398,7 @@ static void _video_acquire_playback_info(void *cls, playback_info_t *info) {
 static float _video_playlist_remove(void *cls) {
     android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
     pthread_mutex_lock(&ctx->playback_info_lock);
+    ctx->last_video_request_ns = _monotonic_ns();
     double position = ctx->playback_position;
     pthread_mutex_unlock(&ctx->playback_info_lock);
     return (float) position;

--- a/app/src/main/cpp/android_raop_callbacks.h
+++ b/app/src/main/cpp/android_raop_callbacks.h
@@ -3,6 +3,7 @@
 
 #include <jni.h>
 #include <pthread.h>
+#include <stdint.h>
 #include "raop.h"
 #include "audio_engine.h"
 
@@ -44,6 +45,14 @@ typedef struct {
     double playback_duration;
     float playback_rate;
     int playback_ready;
+    /* CLOCK_MONOTONIC ns timestamp of the last sender request touching the AirPlay
+       Video session (/play, /rate, /scrub, /stop, GET /playback-info polls,
+       playlist actions). 0 = none seen yet. Guarded by playback_info_lock. Kotlin
+       reads its age via nativeMsSinceVideoRequest for the sender-liveness timeout:
+       some sender apps (seen with iFit) abandon a video without any stop/rate
+       request or disconnect, and the end of their otherwise-continuous
+       /playback-info polling is the only observable signal. */
+    uint64_t last_video_request_ns;
     /* holds the /play response until the player is ready, so self-driven senders (macOS)
        establish their timeline after the real duration is known, not at duration 0 */
     pthread_cond_t play_ready_cond;
@@ -56,6 +65,10 @@ void android_callbacks_destroy(android_callback_ctx_t *ctx, JNIEnv *env);
 void android_callbacks_fill(raop_callbacks_t *cbs, android_callback_ctx_t *ctx);
 void android_callbacks_update_playback_info(android_callback_ctx_t *ctx, double position,
                                              double duration, float rate, int ready);
+
+/* Milliseconds since the last video-session request from the sender, or -1 if none
+   has been seen since init. */
+int64_t android_callbacks_ms_since_video_request(android_callback_ctx_t *ctx);
 
 #ifdef __cplusplus
 }

--- a/app/src/main/cpp/native_bridge.cpp
+++ b/app/src/main/cpp/native_bridge.cpp
@@ -343,6 +343,19 @@ Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeUpdatePlaybackInfo(
     android_callbacks_update_playback_info(&ctx->cb_ctx, position, duration, rate, readyToPlay ? 1 : 0);
 }
 
+/* Milliseconds since the sender last made a request touching the AirPlay Video
+   session (/play, /rate, /scrub, /stop, GET /playback-info polls, playlist
+   actions), or -1 if none yet. Polled by the Kotlin sender-liveness watchdog. */
+extern "C"
+JNIEXPORT jlong JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeMsSinceVideoRequest(
+        JNIEnv *env, jobject thiz, jlong handle) {
+
+    server_ctx_t *ctx = (server_ctx_t *)(intptr_t)handle;
+    if (!ctx) return -1;
+    return (jlong)android_callbacks_ms_since_video_request(&ctx->cb_ctx);
+}
+
 extern "C"
 JNIEXPORT void JNICALL
 Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeSetDefaultStreamValues(

--- a/app/src/main/kotlin/io/github/jqssun/airplay/MainActivity.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/MainActivity.kt
@@ -10,6 +10,7 @@ import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
+import android.os.SystemClock
 import android.util.Rational
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
@@ -27,8 +28,10 @@ import io.github.jqssun.airplay.ui.MainScreen
 import io.github.jqssun.airplay.ui.theme.AirPlayTheme
 import io.github.jqssun.airplay.viewmodel.MainViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
@@ -40,6 +43,13 @@ class MainActivity : ComponentActivity() {
     private val logCallback: (String) -> Unit = { viewModel.addLog(it) }
     private val pinCallback: (String?) -> Unit = { viewModel.showPin(it) }
 
+    // true while this activity is frontmost only because a session summoned it
+    // (service start carrying EXTRA_SESSION_SUMMON); cleared when the user opens
+    // the app themselves or interacts with it outside a session
+    private var summonedBySession = false
+    private var sessionEndJob: Job? = null
+    private var lastSessionEndedAt = 0L
+
     private val connection = object : ServiceConnection {
         override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
             val svc = (binder as? AirPlayService.LocalBinder)?.service ?: return
@@ -47,11 +57,14 @@ class MainActivity : ComponentActivity() {
             svc.logCallback = logCallback
             svc.pinCallback = pinCallback
             viewModel.bindService(svc)
+            _watchSessionEnd(svc)
             if (viewModel.autoStart.value && svc.serverState.value == AirPlayService.ServerState.STOPPED) {
                 viewModel.startServer()
             }
         }
         override fun onServiceDisconnected(name: ComponentName?) {
+            sessionEndJob?.cancel()
+            sessionEndJob = null
             service = null
             viewModel.unbindService()
         }
@@ -64,6 +77,9 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
+        summonedBySession = savedInstanceState?.getBoolean(STATE_SUMMONED_BY_SESSION)
+            ?: (intent?.getBooleanExtra(EXTRA_SESSION_SUMMON, false) == true)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
             ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
@@ -118,6 +134,68 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    // a summon only counts when it actually brings the activity forward; any other
+    // relaunch (launcher, notification) is the user deliberately opening the app
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        if (intent.getBooleanExtra(EXTRA_SESSION_SUMMON, false)) {
+            if (!lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+                summonedBySession = true
+            }
+        } else {
+            summonedBySession = false
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putBoolean(STATE_SUMMONED_BY_SESSION, summonedBySession)
+    }
+
+    // input while no session is active (and none just ended: the tail of the very
+    // gesture that stopped one must not count) means the user wants to be here
+    override fun onUserInteraction() {
+        super.onUserInteraction()
+        if (!summonedBySession) return
+        val justEnded = SystemClock.elapsedRealtime() - lastSessionEndedAt < SESSION_END_INTERACTION_HOLDOFF_MS
+        if (!_sessionActive(service) && !justEnded) {
+            summonedBySession = false
+        }
+    }
+
+    private fun _sessionActive(svc: AirPlayService?) =
+        svc != null && (svc.videoPlaybackActive.value || svc.mirroringActive.value)
+
+    private fun _watchSessionEnd(svc: AirPlayService) {
+        sessionEndJob?.cancel()
+        sessionEndJob = lifecycleScope.launch {
+            var wasActive = false
+            combine(svc.videoPlaybackActive, svc.mirroringActive) { video, mirror -> video || mirror }
+                .distinctUntilChanged()
+                .collect { active ->
+                    if (!active && wasActive) {
+                        lastSessionEndedAt = SystemClock.elapsedRealtime()
+                        _onSessionEnded(svc)
+                    }
+                    wasActive = active
+                }
+        }
+    }
+
+    private fun _onSessionEnded(svc: AirPlayService) {
+        if (!summonedBySession || !viewModel.returnToPreviousApp.value || isInPip.value) return
+        lifecycleScope.launch {
+            // grace period: a sender switching queue items stops one video and plays
+            // the next on the same connection 1-2s later, which re-summons and must
+            // cancel the step-aside instead of flashing through the previous app
+            delay(SESSION_END_RETURN_GRACE_MS)
+            if (_sessionActive(svc)) return@launch
+            if (!summonedBySession || isInPip.value) return@launch
+            summonedBySession = false
+            moveTaskToBack(true)
+        }
+    }
+
     fun enterPip() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
         enterPictureInPictureMode(_pipParams())
@@ -165,5 +243,16 @@ class MainActivity : ComponentActivity() {
         }
         unbindService(connection)
         super.onDestroy()
+    }
+
+    companion object {
+        const val EXTRA_SESSION_SUMMON = "io.github.jqssun.airplay.extra.SESSION_SUMMON"
+        private const val STATE_SUMMONED_BY_SESSION = "summonedBySession"
+        // long enough that a queue-item switch cancels the pending step-aside,
+        // short enough that a real stop still returns promptly
+        private const val SESSION_END_RETURN_GRACE_MS = 2_500L
+        // ignore "user interaction" this long after a session ends, so the stopping
+        // gesture's tail or impatient presses can't clear summonedBySession
+        private const val SESSION_END_INTERACTION_HOLDOFF_MS = 4_000L
     }
 }

--- a/app/src/main/kotlin/io/github/jqssun/airplay/Prefs.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/Prefs.kt
@@ -45,4 +45,5 @@ object Prefs {
     const val ADVERTISE_VIDEO = "advertise_video"; const val DEF_ADVERTISE_VIDEO = true
     const val ADVERTISE_AUDIO = "advertise_audio"; const val DEF_ADVERTISE_AUDIO = true
     const val LAUNCH_ON_CONNECT = "launch_on_connect"; const val DEF_LAUNCH_ON_CONNECT = true
+    const val RETURN_TO_PREVIOUS_APP = "return_to_previous_app"; const val DEF_RETURN_TO_PREVIOUS_APP = true
 }

--- a/app/src/main/kotlin/io/github/jqssun/airplay/bridge/NativeBridge.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/bridge/NativeBridge.kt
@@ -28,6 +28,17 @@ object NativeBridge {
         handle: Long, position: Float, duration: Float, rate: Float, readyToPlay: Boolean
     )
 
+    /**
+     * Milliseconds since the sender last made a request touching the AirPlay Video
+     * session (POST /play, /rate, /scrub, /stop, GET /playback-info polls, playlist
+     * actions), or -1 if none has arrived since native init. Senders poll GET
+     * /playback-info continuously while a video session is mounted -- including
+     * while paused -- so a long silence here while playback isn't progressing means
+     * the sender abandoned the session (see AirPlayService's sender-liveness
+     * watchdog).
+     */
+    external fun nativeMsSinceVideoRequest(handle: Long): Long
+
     external fun nativeGetRaopTxtRecords(handle: Long): Map<String, String>?
     external fun nativeGetAirplayTxtRecords(handle: Long): Map<String, String>?
     external fun nativeGetRaopServiceName(handle: Long): String?

--- a/app/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
@@ -576,9 +576,55 @@ class AirPlayService : LifecycleService(), RaopCallbackHandler, LogListener {
         // lingering polls after a stop must not bounce the UI back to a pending session
         _videoPollSuppressed = true
         _videoPlaybackActive.value = false
+        _mainHandler.removeCallbacks(_senderLivenessTick)
         airPlayVideoPlayer.stop()
         if (!_audioOnly.value) mediaSession?.isActive = false
         log(message)
+    }
+
+    // -- sender-liveness watchdog for AirPlay Video --
+    //
+    // Some sender apps (seen with iFit on iOS) abandon a video without ANY signal
+    // the receiver can react to: no POST /stop, no /rate change, no disconnect --
+    // the AirPlay TCP connections stay open, they just stop driving the stream, so
+    // the receiver would sit on the last frame forever. The one thing that does
+    // change is that the sender's otherwise-continuous GET /playback-info polling
+    // (which keeps going through deliberate pauses) falls silent. The native layer
+    // timestamps every video-session request (NativeBridge.nativeMsSinceVideoRequest);
+    // while a video session is active but NOT progressing, this watchdog treats a
+    // long request silence as sender-abandoned and ends the session. It never
+    // fires while the position is advancing, so a steady-state playing session
+    // can't be killed even if its sender happens to go quiet mid-stream.
+
+    // last position sampled by the watchdog, to detect "not progressing"
+    private var _livenessLastPositionMs = -1L
+
+    private val _senderLivenessTick = object : Runnable {
+        override fun run() {
+            if (!_videoPlaybackActive.value) return
+            _checkSenderLiveness()
+            if (_videoPlaybackActive.value) {
+                _mainHandler.postDelayed(this, SENDER_LIVENESS_CHECK_MS)
+            }
+        }
+    }
+
+    private fun _checkSenderLiveness() {
+        // positionMs comes from the periodic ExoPlayer snapshot; between watchdog
+        // ticks (1s apart) it always moves while playback progresses. It stays frozen
+        // when paused, stalled, errored, or still stuck loading (no snapshot at all).
+        val positionMs = _videoPlaybackInfo.value.positionMs
+        val progressing = positionMs != _livenessLastPositionMs
+        _livenessLastPositionMs = positionMs
+        if (progressing) return
+        val handle = nativeHandle
+        if (handle == 0L) return
+        val silentMs = NativeBridge.nativeMsSinceVideoRequest(handle)
+        // -1 (no request seen) can't normally happen while a session is active,
+        // since the session's own POST /play bumps the timestamp
+        if (silentMs < 0) return
+        if (silentMs < SENDER_ABANDON_TIMEOUT_MS) return
+        _endVideoPlayback("AirPlay Video stopped (sender silent for ${silentMs / 1000}s)")
     }
 
     override fun onDestroy() {
@@ -622,16 +668,26 @@ class AirPlayService : LifecycleService(), RaopCallbackHandler, LogListener {
         // claim media-button routing for keys that arrive as media-session events
         mediaSession?.isActive = true
         log("AirPlay Video play: $location @ ${startPositionSeconds}s")
+        // (re)arm the sender-liveness watchdog for this session
+        _mainHandler.removeCallbacks(_senderLivenessTick)
+        _livenessLastPositionMs = -1L
+        _mainHandler.postDelayed(_senderLivenessTick, SENDER_LIVENESS_CHECK_MS)
         // re-summon on every play, not only first connect: a queue-item switch can
         // land after a summoned activity already stepped back to the previous app
         if (shouldLaunchOnConnect()) launchMainActivity()
     }
 
+    // rate/scrub are logged because sender apps differ wildly in how (or whether)
+    // they signal a stop -- e.g. iFit sends nothing at all -- and the native layer
+    // only logs these requests at debug level, which is compiled to logcat-DEBUG
+    // and above the level the raop logger is set to
     override fun onVideoScrub(positionSeconds: Float) {
+        log("AirPlay Video scrub: ${positionSeconds}s")
         airPlayVideoPlayer.scrub(positionSeconds)
     }
 
     override fun onVideoRate(rate: Float) {
+        log("AirPlay Video rate: $rate")
         airPlayVideoPlayer.setRate(rate)
     }
 
@@ -1119,6 +1175,19 @@ class AirPlayService : LifecycleService(), RaopCallbackHandler, LogListener {
         // shared with dpad/double-tap seeks
         const val VIDEO_SEEK_STEP_MS = 10_000L
         const val VIDEO_POLL_PENDING_TIMEOUT_MS = 3_000L
+
+        /**
+         * Sender-liveness timeout for AirPlay Video: while the session is active
+         * but playback is not progressing (paused/stalled/still loading), a sender
+         * that has made no video-session request (GET /playback-info poll, /rate,
+         * /scrub, ...) for this long is treated as having abandoned the session.
+         * iOS senders normally poll /playback-info about once a second for the
+         * whole life of a session, including while paused via /rate 0, so a
+         * deliberate pause never trips this. Never checked while the position is
+         * advancing.
+         */
+        const val SENDER_ABANDON_TIMEOUT_MS = 10_000L
+        private const val SENDER_LIVENESS_CHECK_MS = 1_000L
 
         private const val AUDIO_CONFIG_DEBOUNCE_MS = 500L
     }

--- a/app/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
@@ -622,6 +622,9 @@ class AirPlayService : LifecycleService(), RaopCallbackHandler, LogListener {
         // claim media-button routing for keys that arrive as media-session events
         mediaSession?.isActive = true
         log("AirPlay Video play: $location @ ${startPositionSeconds}s")
+        // re-summon on every play, not only first connect: a queue-item switch can
+        // land after a summoned activity already stepped back to the previous app
+        if (shouldLaunchOnConnect()) launchMainActivity()
     }
 
     override fun onVideoScrub(positionSeconds: Float) {
@@ -1068,9 +1071,10 @@ class AirPlayService : LifecycleService(), RaopCallbackHandler, LogListener {
     }
 
     private fun launchMainActivity() {
-        Handler(Looper.getMainLooper()).post {
+        _mainHandler.post {
             val launchIntent = Intent(this, MainActivity::class.java)
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+                .putExtra(MainActivity.EXTRA_SESSION_SUMMON, true)
             try {
                 startActivity(launchIntent)
             } catch (e: Exception) {

--- a/app/src/main/kotlin/io/github/jqssun/airplay/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/ui/SettingsScreen.kt
@@ -47,6 +47,7 @@ fun SettingsScreen(viewModel: MainViewModel) {
     val advertiseVideo by viewModel.advertiseVideo.collectAsState()
     val advertiseAudio by viewModel.advertiseAudio.collectAsState()
     val launchOnConnect by viewModel.launchOnConnect.collectAsState()
+    val returnToPreviousApp by viewModel.returnToPreviousApp.collectAsState()
     val maxFps by viewModel.maxFps.collectAsState()
     val overscanned by viewModel.overscanned.collectAsState()
     val requirePin by viewModel.requirePin.collectAsState()
@@ -153,6 +154,13 @@ fun SettingsScreen(viewModel: MainViewModel) {
             trailingContent = {
                 Switch(checked = launchOnConnect, onCheckedChange = null)
             }
+        )
+
+        SettingSwitch(
+            title = stringResource(R.string.setting_return_to_previous_app),
+            description = stringResource(R.string.setting_return_to_previous_app_desc),
+            checked = returnToPreviousApp,
+            onCheckedChange = { viewModel.setReturnToPreviousApp(it) }
         )
 
         SectionHeader(stringResource(R.string.section_display))

--- a/app/src/main/kotlin/io/github/jqssun/airplay/viewmodel/MainViewModel.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/viewmodel/MainViewModel.kt
@@ -189,6 +189,9 @@ class MainViewModel @Inject constructor(app: Application) : AndroidViewModel(app
     private val _launchOnConnect = MutableStateFlow(prefs.getBoolean(Prefs.LAUNCH_ON_CONNECT, Prefs.DEF_LAUNCH_ON_CONNECT))
     val launchOnConnect: StateFlow<Boolean> = _launchOnConnect.asStateFlow()
 
+    private val _returnToPreviousApp = MutableStateFlow(prefs.getBoolean(Prefs.RETURN_TO_PREVIOUS_APP, Prefs.DEF_RETURN_TO_PREVIOUS_APP))
+    val returnToPreviousApp: StateFlow<Boolean> = _returnToPreviousApp.asStateFlow()
+
     // debug
     private val _debugEnabled = MutableStateFlow(prefs.getBoolean(Prefs.DEBUG_ENABLED, Prefs.DEF_DEBUG_ENABLED))
     val debugEnabled: StateFlow<Boolean> = _debugEnabled.asStateFlow()
@@ -410,6 +413,7 @@ class MainViewModel @Inject constructor(app: Application) : AndroidViewModel(app
     fun setAdvertiseVideo(v: Boolean) { _advertiseVideo.value = v; prefs.edit().putBoolean(Prefs.ADVERTISE_VIDEO, v).apply(); _applyByServerRestart() }
     fun setAdvertiseAudio(v: Boolean) { _advertiseAudio.value = v; prefs.edit().putBoolean(Prefs.ADVERTISE_AUDIO, v).apply(); _applyByServerRestart() }
     fun setLaunchOnConnect(v: Boolean) { _launchOnConnect.value = v; prefs.edit().putBoolean(Prefs.LAUNCH_ON_CONNECT, v).apply() }
+    fun setReturnToPreviousApp(v: Boolean) { _returnToPreviousApp.value = v; prefs.edit().putBoolean(Prefs.RETURN_TO_PREVIOUS_APP, v).apply() }
     fun setDebugEnabled(v: Boolean) { _debugEnabled.value = v; prefs.edit().putBoolean(Prefs.DEBUG_ENABLED, v).apply() }
     fun setDeveloperOptions(v: Boolean) {
         _developerOptions.value = v

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,6 +113,8 @@
     <string name="setting_launch_on_connect">Open this application on connect</string>
     <string name="setting_launch_on_connect_desc">Show the screen when a client connects</string>
     <string name="setting_launch_on_connect_no_permission">Tap to grant Display over other apps permission</string>
+    <string name="setting_return_to_previous_app">Return to previous app after casting</string>
+    <string name="setting_return_to_previous_app_desc">Leave the screen when a session that opened this application ends</string>
     <string name="setting_resolution">Resolution</string>
     <string name="setting_resolution_desc">Video resolution advertised to clients</string>
     <string name="setting_resolution_placeholder">[W]x[H]</string>


### PR DESCRIPTION
Stacked follow-up to #21 (return to the previous app): some real iOS senders can end an AirPlay Video session with **no usable protocol signal at all** — no `POST /stop`, no TEARDOWN — leaving the receiver on a frozen frame forever. This PR adds a sender-abandon watchdog so those sessions still end (and, with #21, the TV returns to the previous app).

**Because of the stacking, the "Files changed" tab includes #21's commit too; the single commit that belongs to this PR is best reviewed in the compare view against #21's head: https://github.com/jqssun/android-airplay-server/compare/return-to-previous...session-end-detection**

**Provenance:** this feature was written by Claude (Anthropic AI) agents working under my direction; I drove the real-device testing and reviewed the code.

### Scope change from the earlier draft

The original draft carried two detectors. The **play-connection close detector has been removed from this PR** because it already shipped on main as part of 5cecc50b23ea17566f6eb80c1f4d5ab2035de371 ([`patches/UxPlay/0005-signal-video-reset-on-abandoned-play-connection.patch`](https://github.com/jqssun/android-airplay-server/blob/main/app/src/main/cpp/patches/UxPlay/0005-signal-video-reset-on-abandoned-play-connection.patch)) — thank you for landing that half. What remains here is only the complementary app-side half, re-ported onto current main's structure: the native glue now hooks the `play_ready` condvar path, liveness is surfaced through `onVideoSessionPoll`, and the stop goes through `_endVideoPlayback` like every other session end.

### What it does

**Sender-abandon watchdog (app side only).** Instrumented traces (iFit on iOS) show a sender stopping a video with no observable signal, while the one thing that reliably reflects sender liveness is its `GET /playback-info` polling (~1 Hz for the life of a session, including deliberate pauses). The native glue timestamps every video-session request and exposes the age via `NativeBridge.nativeMsSinceVideoRequest`, and `AirPlayService` runs a 1 s watchdog while a video session is active: if playback is **not progressing** (position frozen: paused, stalled, errored, stuck loading) *and* the sender has made no request for 10 s, the session is ended through `_endVideoPlayback` — the same path as every other stop. The watchdog never fires while the position is advancing, so steady-state playback can't be killed by it. This covers the blind spot of main's conn-close detector: a sender (iFit) whose in-app 'end' keeps the connection open, where the frozen session only clears once the phone locks or the app is backgrounded and polling stops.

Also adds the observability this hunting needed: app-log transitions when sender polling stops/resumes, and a per-tick "sender silent Ns/10s, position frozen" countdown.

### Tuning / maintenance notes

Tunables are unchanged from the earlier draft, in `AirPlayService`'s companion object:

- `SENDER_ABANDON_TIMEOUT_MS` (10 000) — request silence needed (while the position is frozen) before the watchdog ends the session.
- `SENDER_LIVENESS_CHECK_MS` (1 000) — watchdog tick interval.
- Watchdog stops feed the **`AirPlaySummon`**-tagged state machine from #21 — `adb logcat -s AirPlaySummon` is the debugging entry point for any future sender that misbehaves.

### Tested (real devices)

- **2026-08 re-verification, this head:** Sony Bravia, Android TV 9, iOS senders. Stopping the workout inside iFit and locking the phone → TV clears the frozen session ~10 s later and returns to the previous app; a deliberate pause is unaffected (polling continues, watchdog never fires). YouTube video switching, play/pause/scrub regression-free.
- **2025-07 original validation (earlier draft of the same watchdog):** Sony KD-49XD8077 (2016 Bravia, Android TV 8), iFit and YouTube senders; watchdog countdown observed in traces ending abandoned sessions ~10 s after polling stops ("sender silent 1s..10s/10s, position frozen" → session ended → return to previous app).

**Known limitation (documented, not fixed):** iFit's in-app 'end' button sends only `/rate 0` and keeps polling at ~1 Hz — protocol-indistinguishable from a deliberate pause, so nothing fires while the iFit app stays foreground on an awake phone. In practice it self-heals once the iPhone auto-locks or iFit is backgrounded (verified on both devices above). Worst case is a frozen frame for as long as the sender app remains foreground on an awake phone; TV-remote BACK clears it immediately. Main's conn-close detector (0005 patch) covers the complementary case where the sender's connections close while polling had kept the timestamps fresh — belt and braces.

**Test-scope caveat:** two TVs (Android TV 8 and 9) and those two sender apps are the validated matrix so far — not yet tested on other devices, other Android TV versions, or other sender apps. Exercised manually on-device; no automated tests.
