### PR TITLE
feat(audio): native low-latency audio pipeline

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,6 +77,7 @@ android {
 
     buildFeatures {
         compose = true
+        prefab = true
     }
 }
 
@@ -110,6 +111,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.runtime)
+    implementation(libs.androidx.lifecycle.service)
     implementation(libs.androidx.lifecycle.viewmodel)
     implementation(libs.androidx.datastore.prefs)
     implementation(libs.androidx.media)
@@ -118,6 +120,7 @@ dependencies {
     implementation(libs.media3.ui.compose.material3)
     implementation(libs.media3.transformer)
     implementation(libs.kotlinx.coroutines)
+    implementation(libs.oboe)
 
     implementation(platform(libs.compose.bom))
     implementation(libs.compose.ui)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,6 +1,8 @@
 # Keep JNI callback interface (called from native code)
 -keep class io.github.jqssun.airplay.bridge.RaopCallbackHandler { *; }
 -keep class * implements io.github.jqssun.airplay.bridge.RaopCallbackHandler { *; }
+-keep class io.github.jqssun.airplay.bridge.LogListener { *; }
+-keep class * implements io.github.jqssun.airplay.bridge.LogListener { *; }
 
 # Keep NativeBridge native methods
 -keep class io.github.jqssun.airplay.bridge.NativeBridge { *; }

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -20,6 +20,9 @@ set(FORWARD_ANDROID_NDK_ROOT "${ANDROID_NDK}" CACHE STRING "" FORCE) # CI
 list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 add_subdirectory(third_party/openssl-cmake)
 
+# ---------- Oboe (low-latency audio output, via prefab AAR) ----------
+find_package(oboe REQUIRED CONFIG)
+
 # ---------- libplist (built from submodule source) ----------
 set(PLIST_SRC third_party/libplist/src)
 set(PLIST_CNARY third_party/libplist/libcnary)
@@ -110,6 +113,7 @@ set(BRIDGE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/android_dnssd_shim.c
     ${CMAKE_CURRENT_SOURCE_DIR}/android_raop_callbacks.c
     ${CMAKE_CURRENT_SOURCE_DIR}/native_bridge.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/audio_engine.cpp
 )
 
 # ---------- Final shared library ----------
@@ -139,6 +143,8 @@ target_link_libraries(airplay_native
     playfair
     crypto
     plist
+    oboe::oboe
+    mediandk
     log
     android
 )

--- a/app/src/main/cpp/android_raop_callbacks.c
+++ b/app/src/main/cpp/android_raop_callbacks.c
@@ -9,6 +9,7 @@
 #include <errno.h>
 #include <android/log.h>
 #include "android_raop_callbacks.h"
+#include "audio_engine.h"
 
 #define TAG "AirPlayNative"
 #define LOGI(...) __android_log_print(ANDROID_LOG_INFO, TAG, __VA_ARGS__)
@@ -23,6 +24,7 @@ static JNIEnv *_get_env(android_callback_ctx_t *ctx) {
     /* Clear any pending exception from a previous callback on this thread,
        otherwise JNI calls like NewByteArray will fatally abort. */
     if (env && (*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionDescribe(env);
         (*env)->ExceptionClear(env);
     }
     return env;
@@ -34,6 +36,7 @@ void android_callbacks_init(android_callback_ctx_t *ctx, JNIEnv *env, jobject ca
     ctx->h265_enabled = 1;
     ctx->require_pin = 0;
     ctx->registered_count = 0;
+    ctx->audio_engine = NULL;
     memset(ctx->registered_keys, 0, sizeof(ctx->registered_keys));
 
     pthread_mutex_init(&ctx->playback_info_lock, NULL);
@@ -47,7 +50,6 @@ void android_callbacks_init(android_callback_ctx_t *ctx, JNIEnv *env, jobject ca
 
     jclass cls = (*env)->GetObjectClass(env, callback_obj);
     ctx->on_video_data = (*env)->GetMethodID(env, cls, "onVideoData", "([BJZ)V");
-    ctx->on_audio_data = (*env)->GetMethodID(env, cls, "onAudioData", "([BIJI)V");
     ctx->on_audio_format = (*env)->GetMethodID(env, cls, "onAudioFormat", "(IIZ)V");
     ctx->on_video_size = (*env)->GetMethodID(env, cls, "onVideoSize", "(FFFF)V");
     ctx->on_volume_change = (*env)->GetMethodID(env, cls, "onVolumeChange", "(F)V");
@@ -100,14 +102,9 @@ void android_callbacks_update_playback_info(android_callback_ctx_t *ctx, double 
 
 static void _audio_process(void *cls, raop_ntp_t *ntp, audio_decode_struct *data) {
     android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
-    JNIEnv *env = _get_env(ctx);
-    if (!env || !data->data || data->data_len <= 0) return;
-
-    jbyteArray arr = (*env)->NewByteArray(env, data->data_len);
-    (*env)->SetByteArrayRegion(env, arr, 0, data->data_len, (jbyte *)data->data);
-    (*env)->CallVoidMethod(env, ctx->callback_obj, ctx->on_audio_data,
-                           arr, (jint)data->ct, (jlong)data->ntp_time_local, (jint)data->seqnum);
-    (*env)->DeleteLocalRef(env, arr);
+    if (!ctx->audio_engine || !data->data || data->data_len <= 0) return;
+    audio_engine_decode(ctx->audio_engine, data->data, data->data_len,
+                        (int)data->ct, (int64_t)data->ntp_time_local);
 }
 
 static void _video_process(void *cls, raop_ntp_t *ntp, video_decode_struct *data) {

--- a/app/src/main/cpp/android_raop_callbacks.h
+++ b/app/src/main/cpp/android_raop_callbacks.h
@@ -4,6 +4,7 @@
 #include <jni.h>
 #include <pthread.h>
 #include "raop.h"
+#include "audio_engine.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -14,7 +15,6 @@ typedef struct {
     jobject callback_obj;
     raop_t *raop;
     jmethodID on_video_data;
-    jmethodID on_audio_data;
     jmethodID on_audio_format;
     jmethodID on_video_size;
     jmethodID on_volume_change;
@@ -46,6 +46,7 @@ typedef struct {
        establish their timeline after the real duration is known, not at duration 0 */
     pthread_cond_t play_ready_cond;
     int play_ready;
+    AudioEngine *audio_engine;
 } android_callback_ctx_t;
 
 void android_callbacks_init(android_callback_ctx_t *ctx, JNIEnv *env, jobject callback_obj);

--- a/app/src/main/cpp/audio_decoder.h
+++ b/app/src/main/cpp/audio_decoder.h
@@ -1,0 +1,359 @@
+#ifndef AUDIO_DECODER_H
+#define AUDIO_DECODER_H
+
+#include <media/NdkMediaCodec.h>
+#include <media/NdkMediaFormat.h>
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <ctime>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "ALACBitUtilities.h"
+#include "ALACDecoder.h"
+#include "audio_time.h"
+#include "log_sink.h"
+#include "timeline_buffer.h"
+
+static constexpr int CT_ALAC = 2, CT_AAC_LC = 4, CT_AAC_ELD = 8;
+
+class LatencyReporter {
+public:
+    LatencyReporter(const char *name, LogSink &log) : mName(name), mLog(log) {}
+
+    // no concurrent callers
+    void record(int64_t ns) {
+        if (mN == 0 || ns < mMinNs) mMinNs = ns;
+        if (ns > mMaxNs) mMaxNs = ns;
+        mSumNs += ns;
+        if (++mN >= UPDATE_FREQ) {
+            const int32_t meanUs = (int32_t)(mSumNs / mN / 1000);
+            mMeanUs.store(meanUs, std::memory_order_relaxed);
+            mMaxUs.store((int32_t)(mMaxNs / 1000), std::memory_order_relaxed);
+            if (mLogging.load(std::memory_order_relaxed)) {
+                mLog.info("%s latency: n=%lld min=%.2fms mean=%.2fms max=%.2fms (held=%zu)",
+                          mName, (long long)mN, mMinNs / 1e6, meanUs / 1000.0, mMaxNs / 1e6,
+                          mHeld.load(std::memory_order_relaxed));
+            }
+            mN = 0; mSumNs = 0; mMinNs = 0; mMaxNs = 0;
+        }
+    }
+
+    // # of operations currently in flight
+    void setHeld(size_t n) { mHeld.store(n, std::memory_order_relaxed); }
+
+    void setEnableLogging(bool on) { mLogging.store(on, std::memory_order_relaxed); }
+
+    // packed: nests into AudioDebugData with fixed layout
+    struct __attribute__((packed)) Debug {
+        int32_t meanUs, maxUs;  // latency in us
+        uint16_t held;          // operations in flight
+    };
+    Debug debugInfo() const {
+        Debug d{};
+        d.meanUs = mMeanUs.load(std::memory_order_relaxed);
+        d.maxUs = mMaxUs.load(std::memory_order_relaxed);
+        d.held = (uint16_t)mHeld.load(std::memory_order_relaxed);
+        return d;
+    }
+
+private:
+    static constexpr int64_t UPDATE_FREQ = 200;
+
+    const char *mName;
+    LogSink &mLog;                                       // not owned
+    std::atomic<bool> mLogging{false};
+    int64_t mN = 0, mSumNs = 0, mMinNs = 0, mMaxNs = 0;  // producer-thread accumulators
+    std::atomic<int32_t> mMeanUs{0}, mMaxUs{0};
+    std::atomic<size_t> mHeld{0};
+};
+
+// https://stackoverflow.com/a/44095383
+/*
+ * SPSC queue to measure AMediaCodec decode latency: MediaCodec can't carry side data
+ * across decode, so track queue times ourselves
+ */
+struct LatencyProbe {
+    struct Entry { int64_t ptsUs; int64_t queueNs; };
+    static constexpr uint64_t CAP = 64;
+    Entry mBuf[CAP] = {};
+    std::atomic<uint64_t> mWrite{0};
+    std::atomic<uint64_t> mRead{0};
+
+    // call before feeding frame into MediaCodec
+    void record(int64_t ptsUs, int64_t queueNs) {
+        const uint64_t w = mWrite.load(std::memory_order_relaxed);
+        mBuf[w % CAP] = {ptsUs, queueNs};
+        mWrite.store(w + 1, std::memory_order_release);
+    }
+
+    // call after frame comes back; latency ns for ptsUs, or -1 if not recorded
+    int64_t match(int64_t ptsUs, int64_t nowNs) {
+        uint64_t r = mRead.load(std::memory_order_relaxed);
+        const uint64_t w = mWrite.load(std::memory_order_acquire);
+        for (; r < w; r++) {
+            if (mBuf[r % CAP].ptsUs == ptsUs) {
+                const int64_t lat = nowNs - mBuf[r % CAP].queueNs;
+                mRead.store(r + 1, std::memory_order_release);
+                return lat;
+            }
+        }
+        return -1;
+    }
+
+    size_t inFlight() const {
+        return (size_t)(mWrite.load(std::memory_order_relaxed) -
+                        mRead.load(std::memory_order_relaxed));
+    }
+};
+
+// decodes one encoded airplay audio packet and pushes PCM onto the timeline
+class Decoder {
+public:
+    virtual ~Decoder() = default;
+    // called on RAOP receive thread
+    virtual void decode(const uint8_t *data, size_t len, int64_t ptsNs) = 0;
+};
+
+// AMediaCodec decoder; output dequeued on separate thread, shaves ~10ms latency
+class MediaCodecDecoder : public Decoder {
+public:
+    // takes ownership of already-created+started codec
+    MediaCodecDecoder(AMediaCodec *codec, TimelineBuffer &timeline, LatencyReporter &lat)
+        : mCodec(codec), mTimeline(timeline), mLat(lat) {
+        mDrainRun.store(true, std::memory_order_relaxed);
+        mDrainThread = std::thread(&MediaCodecDecoder::drainLoop, this);
+    }
+
+    ~MediaCodecDecoder() override {
+        // stop drain thread before touching the codec it reads from
+        if (mDrainThread.joinable()) {
+            mDrainRun.store(false, std::memory_order_relaxed);
+            mDrainThread.join();
+        }
+        if (mCodec) { AMediaCodec_stop(mCodec); AMediaCodec_delete(mCodec); }
+    }
+
+    void decode(const uint8_t *data, size_t len, int64_t ptsNs) override {
+        ssize_t ii = AMediaCodec_dequeueInputBuffer(mCodec, 5000);
+        if (ii < 0) return;
+        size_t cap = 0;
+        uint8_t *in = AMediaCodec_getInputBuffer(mCodec, (size_t)ii, &cap);
+        if (!in) return;
+        const size_t n = len < cap ? len : cap;
+        memcpy(in, data, n);
+        mProbe.record((int64_t)(ptsNs / 1000), monoNs());
+        AMediaCodec_queueInputBuffer(mCodec, (size_t)ii, 0, n, (uint64_t)(ptsNs / 1000), 0);
+    }
+
+private:
+    static constexpr int64_t DRAIN_TIMEOUT_US = 20000;
+
+    void drainLoop() {
+        AMediaCodecBufferInfo info;
+        while (mDrainRun.load(std::memory_order_relaxed)) {
+            ssize_t oi = AMediaCodec_dequeueOutputBuffer(mCodec, &info, DRAIN_TIMEOUT_US);
+            if (oi < 0) continue;  // timeout / format / buffers changed
+            size_t osz = 0;
+            uint8_t *out = AMediaCodec_getOutputBuffer(mCodec, (size_t)oi, &osz);
+            if (out && info.size > 0) {
+                mTimeline.write((const int16_t *)(out + info.offset),
+                                (size_t)info.size / sizeof(int16_t),  // bytes -> samples
+                                (int64_t)info.presentationTimeUs * 1000);
+            }
+            const int64_t nowNs = monoNs();
+            AMediaCodec_releaseOutputBuffer(mCodec, (size_t)oi, false);
+            const int64_t lat = mProbe.match((int64_t)info.presentationTimeUs, nowNs);
+            if (lat >= 0) mLat.record(lat);
+            mLat.setHeld(mProbe.inFlight());
+        }
+    }
+
+    AMediaCodec *mCodec;                  // owned
+    TimelineBuffer &mTimeline;            // not owned
+    LatencyReporter &mLat;                // not owned
+    LatencyProbe mProbe;
+    std::thread mDrainThread;
+    std::atomic<bool> mDrainRun{false};   // drain thread stop signal
+};
+
+// software ALAC via Apple reference decoder; synchronous, decodes on caller's thread
+class SoftwareAlacDecoder : public Decoder {
+public:
+    SoftwareAlacDecoder(ALACDecoder *alac, TimelineBuffer &timeline, LatencyReporter &lat)
+        : mAlac(alac), mTimeline(timeline), mLat(lat),
+          mPcm((size_t)alac->mConfig.frameLength * alac->mConfig.numChannels) {}
+
+    ~SoftwareAlacDecoder() override { delete mAlac; }
+
+    void decode(const uint8_t *data, size_t len, int64_t ptsNs) override {
+        const int64_t t0 = monoNs();
+
+        BitBuffer bits;
+        BitBufferInit(&bits, (uint8_t *)data, len);
+
+        uint32_t numFrames = mAlac->mConfig.frameLength;
+        uint32_t numChannels = mAlac->mConfig.numChannels;
+
+        uint32_t outSamples = 0;
+        int32_t status = mAlac->Decode(&bits, (uint8_t *)mPcm.data(), numFrames, numChannels,
+                                       &outSamples);
+        if (status == 0 && outSamples > 0) {
+            mLat.record(monoNs() - t0);
+            // reporter is shared and kept across decoder swaps: reset in-flight to 0
+            mLat.setHeld(0);
+            mTimeline.write(mPcm.data(), (size_t)outSamples * numChannels, ptsNs);
+        }
+    }
+
+private:
+    ALACDecoder *mAlac;                   // owned
+    TimelineBuffer &mTimeline;            // not owned
+    LatencyReporter &mLat;                // not owned
+    std::vector<int16_t> mPcm;            // decode scratch
+};
+
+// ---- decoder factories ----
+// create + configure + start AMediaCodec for `mime` with `fmt` (consumes fmt); tries
+// `preferName` first if set, falls back to platform default; nullptr if none start
+static inline AMediaCodec *startCodec(const char *mime, const char *preferName, AMediaFormat *fmt,
+                                      LogSink &log) {
+    AMediaCodec *codec = preferName ? AMediaCodec_createCodecByName(preferName) : nullptr;
+    bool ok = codec &&
+              AMediaCodec_configure(codec, fmt, nullptr, nullptr, 0) == AMEDIA_OK &&
+              AMediaCodec_start(codec) == AMEDIA_OK;
+    if (ok) {
+        log.info("%s decoder started (%s)", mime, preferName);
+    } else {
+        if (codec) { AMediaCodec_delete(codec); codec = nullptr; }
+        codec = AMediaCodec_createDecoderByType(mime);
+        ok = codec &&
+             AMediaCodec_configure(codec, fmt, nullptr, nullptr, 0) == AMEDIA_OK &&
+             AMediaCodec_start(codec) == AMEDIA_OK;
+        if (ok) log.info("%s decoder started (default)", mime);
+    }
+    AMediaFormat_delete(fmt);
+    if (!ok && codec) { AMediaCodec_delete(codec); codec = nullptr; }
+    return ok ? codec : nullptr;
+}
+
+// default AAC decoder runs sandboxed on newer devices; sandbox IPC costs ~15-30ms
+// (Pixel 10), so request the in-process AAC decoder when available
+static constexpr const char *AAC_INPROC_DECODER = "c2.android.inproc.aac.decoder";
+
+// priority=0 requests realtime scheduling; low-latency=1 minimizes decoder buffering
+static inline void setSchedulingHints(AMediaFormat *fmt, bool realtimePriority, bool lowLatency) {
+    if (realtimePriority) AMediaFormat_setInt32(fmt, "priority", 0);
+    if (lowLatency) AMediaFormat_setInt32(fmt, "low-latency", 1);
+}
+
+static inline AMediaCodec *startAacCodec(int ct, int spf, int sampleRate, int channels, LogSink &log,
+                                         bool realtimePriority, bool lowLatency) {
+    uint8_t csd[4]; size_t csdLen; int profile;
+    if (ct == CT_AAC_ELD) {
+        // AAC-ELD AudioSpecificConfig: AOT=39, 44100, stereo, then ELDSpecificConfig whose
+        // first bit is frameLengthFlag (byte2 bit3): 1 = 480 samples/frame (0x50), 0 = 512 (0x40)
+        profile = 39; csd[0] = 0xF8; csd[1] = 0xE8;
+        csd[2] = (spf == 512) ? 0x40 : 0x50; csd[3] = 0x00; csdLen = 4;
+    } else if (ct == CT_AAC_LC) {
+        // AAC-LC AudioSpecificConfig: AOT=2, 44100, stereo, then GASpecificConfig whose
+        // first bit is frameLengthFlag (byte1 bit5): 0 = 1024 samples/frame (0x10), 1 = 960 (0x14)
+        profile = 2; csd[0] = 0x12;
+        csd[1] = (spf == 960) ? 0x14 : 0x10; csdLen = 2;
+    } else {
+        log.error("Unknown audio ct=%d", ct); return nullptr;
+    }
+    AMediaFormat *fmt = AMediaFormat_new();
+    AMediaFormat_setString(fmt, "mime", "audio/mp4a-latm");
+    AMediaFormat_setInt32(fmt, "sample-rate", sampleRate);
+    AMediaFormat_setInt32(fmt, "channel-count", channels);
+    AMediaFormat_setInt32(fmt, "aac-profile", profile);
+    AMediaFormat_setInt32(fmt, "is-adts", 0);
+    setSchedulingHints(fmt, realtimePriority, lowLatency);
+    AMediaFormat_setBuffer(fmt, "csd-0", csd, csdLen);
+    return startCodec("audio/mp4a-latm", AAC_INPROC_DECODER, fmt, log);
+}
+
+// 24-byte ALACSpecificConfig "magic cookie" (big-endian)
+static inline void buildAlacMagicCookie(uint8_t out[24], int sampleRate, int channels, int spf) {
+    const int frameLength = spf;
+    const int bitDepth = 16, pb = 40, mb = 10, kb = 14;
+    out[0] = (frameLength >> 24) & 0xFF;
+    out[1] = (frameLength >> 16) & 0xFF;
+    out[2] = (frameLength >> 8) & 0xFF;
+    out[3] = frameLength & 0xFF;
+    out[4] = 0;                /* compatibleVersion */
+    out[5] = (uint8_t)bitDepth;
+    out[6] = (uint8_t)pb;
+    out[7] = (uint8_t)mb;
+    out[8] = (uint8_t)kb;
+    out[9] = (uint8_t)channels;
+    out[10] = 0; out[11] = 0xFF; /* maxRun = 255 (big-endian) */
+    out[12] = out[13] = out[14] = out[15] = 0; /* maxFrameBytes */
+    out[16] = out[17] = out[18] = out[19] = 0; /* avgBitRate */
+    out[20] = (sampleRate >> 24) & 0xFF;
+    out[21] = (sampleRate >> 16) & 0xFF;
+    out[22] = (sampleRate >> 8) & 0xFF;
+    out[23] = sampleRate & 0xFF;
+}
+
+static inline AMediaCodec *startAlacHwCodec(int sampleRate, int channels, int spf, LogSink &log,
+                                            bool realtimePriority, bool lowLatency) {
+    AMediaFormat *fmt = AMediaFormat_new();
+    AMediaFormat_setString(fmt, "mime", "audio/alac");
+    AMediaFormat_setInt32(fmt, "sample-rate", sampleRate);
+    AMediaFormat_setInt32(fmt, "channel-count", channels);
+    setSchedulingHints(fmt, realtimePriority, lowLatency);
+    // cookie wrapped in its atom: 4-byte size + 'alac' + 4-byte version/flags, then
+    // 24-byte ALACSpecificConfig
+    uint8_t csd[36] = { 0x00, 0x00, 0x00, 0x24, 0x61, 0x6C, 0x61, 0x63 };
+    buildAlacMagicCookie(csd + 12, sampleRate, channels, spf);
+    AMediaFormat_setBuffer(fmt, "csd-0", csd, sizeof(csd));
+    return startCodec("audio/alac", nullptr, fmt, log);
+}
+
+static inline ALACDecoder *makeSwAlac(int sampleRate, int channels, int spf) {
+    ALACDecoder *dec = new ALACDecoder();
+    if (!dec) return nullptr;
+
+    uint8_t cookie[24];
+    buildAlacMagicCookie(cookie, sampleRate, channels, spf);
+    if (dec->Init(cookie, sizeof(cookie)) != 0) {
+        delete dec;
+        return nullptr;
+    }
+    return dec;
+}
+
+static inline std::unique_ptr<Decoder> makeDecoder(int ct, int spf, int sampleRate, int channels,
+                                                   TimelineBuffer &timeline, LatencyReporter &lat,
+                                                   LogSink &log, bool forceSwAlac,
+                                                   bool realtimePriority, bool lowLatency) {
+    if (ct == CT_ALAC) {
+        if (!forceSwAlac) {
+            if (AMediaCodec *codec = startAlacHwCodec(sampleRate, channels, spf, log,
+                                                      realtimePriority, lowLatency)) {
+                log.info("ALAC: hardware decoder");
+                return std::make_unique<MediaCodecDecoder>(codec, timeline, lat);
+            }
+        }
+        if (ALACDecoder *alac = makeSwAlac(sampleRate, channels, spf)) {
+            log.info("ALAC: software decoder%s", forceSwAlac ? " (forced)" : "");
+            return std::make_unique<SoftwareAlacDecoder>(alac, timeline, lat);
+        }
+        log.error("ALAC init failed (hw and sw)");
+        return nullptr;
+    }
+    if (AMediaCodec *codec = startAacCodec(ct, spf, sampleRate, channels, log,
+                                           realtimePriority, lowLatency)) {
+        return std::make_unique<MediaCodecDecoder>(codec, timeline, lat);
+    }
+    log.error("AAC codec init failed (ct=%d)", ct);
+    return nullptr;
+}
+
+#endif  // AUDIO_DECODER_H

--- a/app/src/main/cpp/audio_engine.cpp
+++ b/app/src/main/cpp/audio_engine.cpp
@@ -1,0 +1,266 @@
+/*
+ * Native low-latency audio pipeline for the airplay receiver, three layers:
+ *   decoding (AAC/ALAC) -> timing/jitter buffer (spike absorption + PTS sync) -> PCM output
+ */
+
+#include <jni.h>
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include "audio_engine.h"
+#include "audio_decoder.h"
+#include "audio_output.h"
+#include "log_sink.h"
+#include "timeline_buffer.h"
+
+/*
+ * debug metrics copied out to Java each overlay poll (see copyDebug). MUST BE PACKED,
+ * including nested structs: Java reader (AudioRenderer.audioDebug) mirrors this exact
+ * byte layout
+ */
+struct __attribute__((packed)) AudioDebugData {
+    TimelineBuffer::Debug timeline;
+    LatencyReporter::Debug decode;
+    AudioOutput::Debug output;
+};
+
+struct AudioConfig {
+    const int staticCushionMs;   // 0 = adaptive tuner
+    const int percentilePct;     // adaptive tuner target percentile
+    const int oboeBufferFrames;  // 0 = auto, two bursts in low-latency mode, oboe default in power save
+    const bool forceSwAlac;      // embedded Apple software ALAC even when HW available
+    const bool realtimePriority; // decoder: request realtime priority
+    const bool lowLatency;       // low-latency decoder + oboe low-latency output
+    const bool benchmarkLog;     // periodically log decoder stats
+};
+
+struct CodecFormat {
+    int spf = 0;  // samples/frame; 0 = not yet announced (decoder uses built-in default)
+    bool operator==(const CodecFormat &o) const { return spf == o.spf; }
+    bool operator!=(const CodecFormat &o) const { return !(*this == o); }
+};
+
+struct AudioEngine {
+    AudioEngine(std::shared_ptr<LogSink> log, int sampleRate, int channels)
+        : mLog(std::move(log)), mSampleRate(sampleRate), mChannels(channels) {
+        mQueued[ctIndex(CT_ALAC)].store(CodecFormat{352}, std::memory_order_relaxed);
+        mQueued[ctIndex(CT_AAC_LC)].store(CodecFormat{1024}, std::memory_order_relaxed);
+        mQueued[ctIndex(CT_AAC_ELD)].store(CodecFormat{480}, std::memory_order_relaxed);
+    }
+
+    ~AudioEngine() {
+        delete mPending.load(std::memory_order_relaxed);
+    }
+
+    bool configure(const AudioConfig &cfg) {
+        std::lock_guard<std::mutex> lk(mRebuildLock);
+        if (!mApplied) {
+            initInternals(cfg);
+            return true;
+        }
+        // engine may be in use: decode() applies the queued config
+        delete mPending.exchange(new AudioConfig(cfg), std::memory_order_release);
+        return true;
+    }
+
+    bool start() {
+        std::lock_guard<std::mutex> lk(mRebuildLock);
+        mRunning = true;
+        if (mOutput && !mOutputActive) {
+            mTimeline->flushAndReprime();
+            mOutputActive = mOutput->start();
+        }
+        return mOutputActive;
+    }
+
+    void pause() {
+        std::lock_guard<std::mutex> lk(mRebuildLock);
+        mRunning = false;
+        if (mOutput && mOutputActive) {
+            mOutput->stop();
+            mOutputActive = false;
+        }
+    }
+
+    // touches decoder: must not run concurrently with decode()
+    void stop() {
+        if (mOutput) mOutput->stop();
+        mOutputActive = false;
+        mDecoder = {};
+    }
+
+    void setVolume(float v) {
+        std::lock_guard<std::mutex> lk(mRebuildLock);
+        mVolume = v;
+        if (mOutput) mOutput->setVolume(v);
+    }
+
+    void onFormat(int ct, int spf) {
+        const int i = ctIndex(ct);
+        if (i < 0 || spf <= 0) return;
+        mQueued[i].store(CodecFormat{spf}, std::memory_order_release);
+    }
+
+    bool copyDebug(void *dst, size_t dstLen) {
+        if (dstLen < sizeof(AudioDebugData)) return false;
+        {
+            // never block: return stale data if lock in use
+            std::unique_lock<std::mutex> lk(mRebuildLock, std::try_to_lock);
+            if (lk.owns_lock() && mOutput) {
+                mDebug.timeline = mTimeline->debugInfo();
+                mDebug.decode = mDecLatency.debugInfo();
+                mDebug.output = mOutput->debugInfo();
+            }
+        }
+        memcpy(dst, &mDebug, sizeof(mDebug));
+        return true;
+    }
+
+    // touches decoder: must not run concurrently with stop()
+    void decode(const uint8_t *data, size_t len, int ct, int64_t ptsNs) {
+        if (!mTimeline) return;
+        if (mPending.load(std::memory_order_relaxed)) {
+            if (AudioConfig *raw = mPending.exchange(nullptr, std::memory_order_acquire)) {
+                std::unique_ptr<AudioConfig> c(raw);
+                mDecoder = {};
+                std::lock_guard<std::mutex> lk(mRebuildLock);
+                if (mOutputActive) mOutput->stop();
+                mOutput.reset();
+                initInternals(*c);
+                mOutputActive = mRunning ? mOutput->start() : false;
+            }
+        }
+
+        const int ci = ctIndex(ct);
+        const CodecFormat wantConfig = ci >= 0 ? mQueued[ci].load(std::memory_order_acquire) : CodecFormat{};
+        if (ct != mDecoder.ct || wantConfig != mDecoder.format) {
+            mDecoder = {}; // release old decoder first to free resources
+            mDecoder = {ct, wantConfig,
+                        makeDecoder(ct, wantConfig.spf, mSampleRate, mChannels, *mTimeline,
+                                    mDecLatency, *mLog, mApplied->forceSwAlac,
+                                    mApplied->realtimePriority, mApplied->lowLatency)};
+            // codec switch is definitely a discontinuity
+            mTimeline->reanchorTracker();
+        }
+        if (mDecoder.decoder) mDecoder.decoder->decode(data, len, ptsNs);
+    }
+
+private:
+    static int ctIndex(int ct) {
+        switch (ct) {
+            case CT_ALAC:    return 0;
+            case CT_AAC_LC:  return 1;
+            case CT_AAC_ELD: return 2;
+            default:         return -1;
+        }
+    }
+
+    void initInternals(const AudioConfig &cfg) {
+        mDecLatency.setEnableLogging(cfg.benchmarkLog);
+        mTimeline = std::make_shared<TimelineBuffer>(mSampleRate, mChannels,
+                                                     cfg.staticCushionMs, cfg.percentilePct);
+        mOutput = AudioOutput::create(mSampleRate, mChannels, cfg.oboeBufferFrames,
+                                      cfg.lowLatency, mTimeline, mLog);
+        mOutput->setVolume(mVolume);  // carry current level across rebuild
+        mApplied = std::make_unique<AudioConfig>(cfg);
+    }
+
+    const int mSampleRate;
+    const int mChannels;
+    std::unique_ptr<AudioConfig> mApplied;
+    std::shared_ptr<LogSink> mLog;
+
+    // thread safety: decode thread reads mTimeline/mOutput unguarded (nothing else writes them outside teardown) and writes them under mRebuildLock
+    // all other threads read them under mRebuildLock; mDecoder is decode-thread-only
+    // teardown stop() requires caller to guarantee no in-flight or future decode() calls
+
+    std::mutex mRebuildLock;
+    std::shared_ptr<TimelineBuffer> mTimeline; // guarded by mRebuildLock
+    std::shared_ptr<AudioOutput> mOutput;      // guarded by mRebuildLock
+    bool mRunning = false;                     // requested output state, guarded by mRebuildLock
+    bool mOutputActive = false;                // actual output state, guarded by mRebuildLock
+    float mVolume = 1.0f;                      // last-set output level, guarded by mRebuildLock
+
+    LatencyReporter mDecLatency{"decode", *mLog};
+    // decoder + codec/config it was built with
+    // ct == -1: not initialized; ct != -1 && decoder == nullptr: build for ct failed
+    struct CreatedDecoder {
+        int ct = -1;
+        CodecFormat format;
+        std::unique_ptr<Decoder> decoder;
+    };
+    CreatedDecoder mDecoder;
+
+    // wanted config per codec, keyed by ctIndex
+    static constexpr int NUM_CT = 3;
+    std::atomic<CodecFormat> mQueued[NUM_CT] = {};
+
+    // pending config change, applied on next decode()
+    std::atomic<AudioConfig *> mPending{nullptr};
+
+    AudioDebugData mDebug{};
+};
+
+AudioEngine *audio_engine_create(std::shared_ptr<LogSink> log, int sampleRate, int channels) {
+    if (!log) return nullptr;
+    return new AudioEngine(std::move(log), sampleRate, channels);
+}
+
+
+
+extern "C" {
+
+void audio_engine_set_default_stream_values(int sampleRate, int framesPerBurst) {
+    // configures oboe's OpenSL ES backend for pre-AAudio devices
+    if (sampleRate > 0) oboe::DefaultStreamValues::SampleRate = sampleRate;
+    if (framesPerBurst > 0) oboe::DefaultStreamValues::FramesPerBurst = framesPerBurst;
+}
+
+bool audio_engine_configure(AudioEngine *engine, int cushionMs, int percentilePct,
+                            int oboeBufferFrames, bool forceSwAlac, bool realtimePriority,
+                            bool lowLatency, bool benchmarkLog) {
+    if (!engine) return false;
+    return engine->configure({cushionMs, percentilePct, oboeBufferFrames, forceSwAlac,
+                              realtimePriority, lowLatency, benchmarkLog});
+}
+
+void audio_engine_set_volume(AudioEngine *engine, float volume) {
+    if (engine) engine->setVolume(volume);
+}
+
+void audio_engine_on_format(AudioEngine *engine, int ct, int spf) {
+    if (engine) engine->onFormat(ct, spf);
+}
+
+bool audio_engine_start(AudioEngine *engine) {
+    return engine && engine->start();
+}
+
+void audio_engine_pause(AudioEngine *engine) {
+    if (engine) engine->pause();
+}
+
+bool audio_engine_get_debug(AudioEngine *engine, void *dst, size_t dstLen) {
+    if (!engine || !dst) return false;
+    return engine->copyDebug(dst, dstLen);
+}
+
+void audio_engine_destroy(AudioEngine *engine) {
+    if (!engine) return;
+    engine->stop();
+    delete engine;
+}
+
+// decode straight from RAOP audio callback, no JNI crossing
+void audio_engine_decode(AudioEngine *engine, const uint8_t *data, int len, int ct, int64_t pts_ns) {
+    if (engine && data && len > 0) {
+        engine->decode(data, (size_t)len, ct, pts_ns);
+    }
+}
+
+}

--- a/app/src/main/cpp/audio_engine.h
+++ b/app/src/main/cpp/audio_engine.h
@@ -1,0 +1,61 @@
+#ifndef AUDIO_ENGINE_H
+#define AUDIO_ENGINE_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* native audio engine: decodes, buffers and outputs audio; config can change while active */
+typedef struct AudioEngine AudioEngine;
+
+/* native -> UI log channel, opaque here (C++ type) */
+typedef struct LogSink LogSink;
+
+/* report device's native output sample rate + frames-per-burst (from AudioManager) to
+ * oboe. its OpenSL ES backend (pre-AAudio devices) can't discover these itself and
+ * needs them to size low-latency buffers; unused by AAudio backend. global, call before
+ * creating engine.
+ * see: https://github.com/google/oboe/blob/main/docs/GettingStarted.md#obtaining-optimal-latency */
+void audio_engine_set_default_stream_values(int sampleRate, int framesPerBurst);
+
+/* change engine config; any thread */
+bool audio_engine_configure(AudioEngine *engine, int cushionMs, int percentilePct,
+                            int oboeBufferFrames, bool forceSwAlac, bool realtimePriority,
+                            bool lowLatency, bool benchmarkLog);
+
+/* output volume, linear gain */
+void audio_engine_set_volume(AudioEngine *engine, float volume);
+
+/* sender is switching audio formats */
+void audio_engine_on_format(AudioEngine *engine, int ct, int spf);
+
+/* begin or resume playout; false if stream fails to open; idempotent */
+bool audio_engine_start(AudioEngine *engine);
+
+/* pause playout, releases audio output devices while paused; idempotent */
+void audio_engine_pause(AudioEngine *engine);
+
+/* refresh + copy packed debug struct into dst; false if engine NULL or dstLen too small */
+bool audio_engine_get_debug(AudioEngine *engine, void *dst, size_t dstLen);
+
+/* stop + destroy engine; no concurrent or later audio_engine_decode calls allowed */
+void audio_engine_destroy(AudioEngine *engine);
+
+/* decode + play one encoded airplay packet; not concurrent with audio_engine_destroy */
+void audio_engine_decode(AudioEngine *engine, const uint8_t *data, int len, int ct, int64_t pts_ns);
+
+#ifdef __cplusplus
+}
+
+#include <memory>
+
+/* create engine; handle or NULL */
+extern "C++" AudioEngine *audio_engine_create(std::shared_ptr<LogSink> log, int sampleRate,
+                                              int channels);
+#endif
+
+#endif  // AUDIO_ENGINE_H

--- a/app/src/main/cpp/audio_output.h
+++ b/app/src/main/cpp/audio_output.h
@@ -1,0 +1,196 @@
+#ifndef AUDIO_OUTPUT_H
+#define AUDIO_OUTPUT_H
+
+#include <oboe/Oboe.h>
+#include <atomic>
+#include <memory>
+#include <mutex>
+
+#include "log_sink.h"
+#include "timeline_buffer.h"
+
+class AudioOutput;
+
+// https://github.com/google/oboe/wiki/TechNote_HowToAvoidCrashes#avoid-deleting-objects-that-are-used-by-callbacks
+/*
+ * oboe data/error callbacks. oboe can invoke these even after stop()/close():
+ * this object owns refs to everything the callbacks touch: a late callback can never
+ * reach freed state. holds only weak_ptr to AudioOutput to break the ownership cycles
+ * AudioOutput -> OboeCallbacks -> AudioOutput and
+ * AudioOutput -> oboe::AudioStream -> OboeCallbacks -> AudioOutput
+ */
+class OboeCallbacks : public oboe::AudioStreamDataCallback,
+                      public oboe::AudioStreamErrorCallback {
+public:
+    OboeCallbacks(std::shared_ptr<TimelineBuffer> timeline, std::shared_ptr<LogSink> log,
+                  int channels)
+        : mTimeline(std::move(timeline)), mLog(std::move(log)), mChannels(channels) {}
+
+    void setVolume(float v) { mVolume.store(v, std::memory_order_relaxed); }
+
+    oboe::DataCallbackResult onAudioReady(oboe::AudioStream *, void *audioData,
+                                          int32_t numFrames) override {
+        auto *out = static_cast<int16_t *>(audioData);
+        mTimeline->read(out, numFrames);
+
+        const float vol = mVolume.load(std::memory_order_relaxed);
+        if (vol < 0.999f) {
+            const size_t n = (size_t)numFrames * mChannels;
+            for (size_t i = 0; i < n; i++) out[i] = (int16_t)(out[i] * vol);
+        }
+        return oboe::DataCallbackResult::Continue;
+    }
+
+    void onErrorAfterClose(oboe::AudioStream *, oboe::Result error) override;  // needs AudioOutput
+
+private:
+    friend class AudioOutput;
+
+    std::shared_ptr<TimelineBuffer> mTimeline;
+    std::shared_ptr<LogSink> mLog;
+    const int mChannels;
+    std::atomic<float> mVolume{1.0f};
+    std::weak_ptr<AudioOutput> mOwner;
+};
+
+/*
+ * low-latency audio output via oboe (AAudio or OpenSL ES). data callback pulls PCM from
+ * TimelineBuffer and applies volume; transparently handles device-loss errors
+ * (e.g. BT/headset change)
+ */
+class AudioOutput {
+public:
+    static std::shared_ptr<AudioOutput> create(int sampleRate, int channels, int oboeBufferFrames,
+                                               bool lowLatency,
+                                               std::shared_ptr<TimelineBuffer> timeline,
+                                               std::shared_ptr<LogSink> log) {
+        auto out = std::make_shared<AudioOutput>(sampleRate, channels, oboeBufferFrames,
+                                                 lowLatency, std::move(timeline), std::move(log));
+        out->mCallbacks->mOwner = out;
+        return out;
+    }
+
+    AudioOutput(int sampleRate, int channels, int oboeBufferFrames, bool lowLatency,
+                std::shared_ptr<TimelineBuffer> timeline, std::shared_ptr<LogSink> log)
+        : mSampleRate(sampleRate), mChannels(channels), mOboeBufferFrames(oboeBufferFrames),
+          mLowLatency(lowLatency), mTimeline(std::move(timeline)), mLog(std::move(log)),
+          mCallbacks(std::make_shared<OboeCallbacks>(mTimeline, mLog, channels)) {}
+
+    ~AudioOutput() { stop(); }
+
+    bool start() {
+        std::lock_guard<std::mutex> lk(mLock);
+        mClosing.store(false);
+        if (!openLocked()) return false;
+        if (mStream->requestStart() != oboe::Result::OK) {
+            mStream->close();
+            mStream.reset();
+            return false;
+        }
+        return true;
+    }
+
+    void stop() {
+        std::lock_guard<std::mutex> lk(mLock);
+        mClosing.store(true);
+        if (mStream) {
+            mStream->stop();
+            mStream->close();
+            mStream.reset();
+        }
+    }
+
+    void setVolume(float v) { mCallbacks->setVolume(v); }
+
+    // packed: nests into AudioDebugData with fixed layout
+    struct __attribute__((packed)) Debug {
+        int32_t xrun;  // cumulative
+    };
+    Debug debugInfo() {
+        Debug d{};
+        std::lock_guard<std::mutex> lk(mLock);
+        if (mStream) { auto r = mStream->getXRunCount(); if (r) d.xrun = r.value(); }
+        return d;
+    }
+
+private:
+    friend class OboeCallbacks;
+
+    // oboe error thread, on device loss: reopen and restart unless tearing down
+    void reopenAfterError() {
+        std::lock_guard<std::mutex> lk(mLock);
+        if (mClosing.load()) return;
+        mStream.reset();
+        mTimeline->reprime();
+        if (openLocked()) mStream->requestStart();
+    }
+
+    bool openLocked() {  // caller holds mLock
+        // see: https://developer.android.com/games/sdk/oboe/low-latency-audio
+        oboe::AudioStreamBuilder b;
+        b.setDirection(oboe::Direction::Output)
+            ->setSharingMode(oboe::SharingMode::Shared)
+            ->setFormat(oboe::AudioFormat::I16)
+            ->setChannelCount(mChannels)
+            ->setSampleRate(mSampleRate)
+            ->setSampleRateConversionQuality(oboe::SampleRateConversionQuality::Medium)
+            ->setContentType(oboe::ContentType::Music)
+            ->setDataCallback(mCallbacks)
+            ->setErrorCallback(mCallbacks);
+        if (mLowLatency) {
+            // game use case may enable extra latency optimizations
+            b.setPerformanceMode(oboe::PerformanceMode::LowLatency)->setUsage(oboe::Usage::Game);
+        } else {
+            // media use case may have better quality and lower power
+            b.setPerformanceMode(oboe::PerformanceMode::PowerSaving)->setUsage(oboe::Usage::Media);
+        }
+        oboe::Result r = b.openStream(mStream);
+        if (r != oboe::Result::OK) {
+            mLog->error("Failed to open Oboe stream: %s", oboe::convertToText(r));
+            return false;
+        }
+        if (mOboeBufferFrames > 0) {
+            mStream->setBufferSizeInFrames(mOboeBufferFrames);
+        } else if (mLowLatency) {
+            // smallest reasonable buffer in low-latency mode
+            mStream->setBufferSizeInFrames(mStream->getFramesPerBurst() * 2);
+        }
+
+        // log what we actually got: oboe may clamp the buffer, fall back to a
+        // higher-latency API, or deny the low-latency path
+        const bool aaudio = mStream->getAudioApi() == oboe::AudioApi::AAudio;
+        const char *api = aaudio ? "AAudio"
+                        : mStream->getAudioApi() == oboe::AudioApi::OpenSLES ? "OpenSLES" : "?";
+        const bool lowLatency = mStream->getPerformanceMode() == oboe::PerformanceMode::LowLatency;
+        const bool mmap = aaudio && oboe::OboeExtensions::isMMapUsed(mStream.get());
+        mLog->info("Oboe out: %s%s, mmap=%s, buffer=%d/%d frames, burst=%d, %d Hz",
+                  api, lowLatency ? " (low-latency)" : "", mmap ? "yes" : "no",
+                  mStream->getBufferSizeInFrames(), mStream->getBufferCapacityInFrames(),
+                  mStream->getFramesPerBurst(), mStream->getSampleRate());
+        // adaptive tuner needs final buffer size
+        mTimeline->noteOutputBufferFrames(mStream->getBufferSizeInFrames());
+        return true;
+    }
+
+    const int mSampleRate;
+    const int mChannels;
+
+    const int mOboeBufferFrames;
+    const bool mLowLatency;
+
+    std::shared_ptr<TimelineBuffer> mTimeline;
+    std::shared_ptr<LogSink> mLog;
+    std::atomic<bool> mClosing{false};
+    std::shared_ptr<OboeCallbacks> mCallbacks;
+    std::shared_ptr<oboe::AudioStream> mStream;
+    std::mutex mLock;                    // guards open/close
+};
+
+inline void OboeCallbacks::onErrorAfterClose(oboe::AudioStream *, oboe::Result error) {
+    // device disconnect (e.g. BT/headset change): oboe already closed the stream, ask
+    // AudioOutput to reopen
+    mLog->error("Oboe stream error: %s - reopening", oboe::convertToText(error));
+    if (auto owner = mOwner.lock()) owner->reopenAfterError();
+}
+
+#endif  // AUDIO_OUTPUT_H

--- a/app/src/main/cpp/audio_time.h
+++ b/app/src/main/cpp/audio_time.h
@@ -1,0 +1,15 @@
+#ifndef AUDIO_TIME_H
+#define AUDIO_TIME_H
+
+#include <cstdint>
+#include <ctime>
+
+static constexpr int64_t NS_PER_SEC = 1000000000LL;
+
+static inline int64_t monoNs() {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (int64_t)ts.tv_sec * NS_PER_SEC + ts.tv_nsec;
+}
+
+#endif  // AUDIO_TIME_H

--- a/app/src/main/cpp/log_sink.h
+++ b/app/src/main/cpp/log_sink.h
@@ -1,0 +1,75 @@
+#ifndef LOG_SINK_H
+#define LOG_SINK_H
+
+#include <android/log.h>
+#include <jni.h>
+#include <cstdarg>
+#include <cstdio>
+
+#define LOG_SINK_TAG "AirPlayNative"
+
+/*
+ * log sink writing to both app log UI and logcat. any thread may emit, but emitting can
+ * be slow (JNI call)
+ */
+class LogSink {
+public:
+    // bind to Kotlin handler with `void onLog(String)` (bridge.LogListener)
+    void bind(JNIEnv *env, jobject handler) {
+        env->GetJavaVM(&mVm);
+        mObj = env->NewGlobalRef(handler);
+        jclass cls = env->GetObjectClass(handler);
+        mMethod = cls ? env->GetMethodID(cls, "onLog", "(Ljava/lang/String;)V") : nullptr;
+        if (cls) env->DeleteLocalRef(cls);
+    }
+
+    // releases handler global ref; thread safe
+    ~LogSink() {
+        if (!mVm || !mObj) return;
+        JNIEnv *env = nullptr;
+        bool attached = false;
+        if (mVm->GetEnv((void **)&env, JNI_VERSION_1_6) == JNI_EDETACHED) {
+            if (mVm->AttachCurrentThread(&env, nullptr) != JNI_OK) return;
+            attached = true;
+        }
+        env->DeleteGlobalRef(mObj);
+        if (attached) mVm->DetachCurrentThread();
+    }
+
+    // log level only affects logcat, UI ignores it
+    void info(const char *fmt, ...)  __attribute__((format(printf, 2, 3))) {
+        va_list ap; va_start(ap, fmt); vemit(ANDROID_LOG_INFO, fmt, ap); va_end(ap);
+    }
+    void warn(const char *fmt, ...)  __attribute__((format(printf, 2, 3))) {
+        va_list ap; va_start(ap, fmt); vemit(ANDROID_LOG_WARN, fmt, ap); va_end(ap);
+    }
+    void error(const char *fmt, ...) __attribute__((format(printf, 2, 3))) {
+        va_list ap; va_start(ap, fmt); vemit(ANDROID_LOG_ERROR, fmt, ap); va_end(ap);
+    }
+
+private:
+    void vemit(int prio, const char *fmt, va_list ap) {
+        char buf[256];
+        vsnprintf(buf, sizeof(buf), fmt, ap);
+        __android_log_print(prio, LOG_SINK_TAG, "%s", buf);
+        if (!mVm || !mObj || !mMethod) return;
+
+        JNIEnv *env = nullptr;
+        bool attached = false;
+        if (mVm->GetEnv((void **)&env, JNI_VERSION_1_6) == JNI_EDETACHED) {
+            if (mVm->AttachCurrentThread(&env, nullptr) != JNI_OK) return;
+            attached = true;
+        }
+        jstring s = env->NewStringUTF(buf);
+        env->CallVoidMethod(mObj, mMethod, s);
+        if (env->ExceptionCheck()) { env->ExceptionDescribe(); env->ExceptionClear(); }
+        env->DeleteLocalRef(s);
+        if (attached) mVm->DetachCurrentThread();
+    }
+
+    JavaVM *mVm = nullptr;
+    jobject mObj = nullptr;      // global ref to JNI handler
+    jmethodID mMethod = nullptr; // onLog(String)
+};
+
+#endif  // LOG_SINK_H

--- a/app/src/main/cpp/native_bridge.cpp
+++ b/app/src/main/cpp/native_bridge.cpp
@@ -5,6 +5,7 @@
 #include <jni.h>
 #include <string.h>
 #include <stdlib.h>
+#include <memory>
 #include <android/log.h>
 
 extern "C" {
@@ -16,8 +17,8 @@ extern "C" {
 #include "android_dnssd_shim.h"
 }
 
-#include "ALACDecoder.h"
-#include "ALACBitUtilities.h"
+#include "audio_engine.h"
+#include "log_sink.h"
 
 #define TAG "AirPlayNative"
 #define LOGI(...) __android_log_print(ANDROID_LOG_INFO, TAG, __VA_ARGS__)
@@ -30,6 +31,7 @@ typedef struct {
     android_callback_ctx_t cb_ctx;
     raop_callbacks_t callbacks;
     char hw_addr[6];
+    std::shared_ptr<LogSink> log;
 } server_ctx_t;
 
 static void _log_callback(void *cls, int level, const char *msg) {
@@ -47,8 +49,7 @@ Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeInit(
         jobject callback, jbyteArray hwAddr, jstring name, jstring keyFile,
         jboolean nohold, jboolean requirePin) {
 
-    server_ctx_t *ctx = (server_ctx_t *)calloc(1, sizeof(server_ctx_t));
-    if (!ctx) return 0;
+    server_ctx_t *ctx = new server_ctx_t();
 
     jsize hw_len = env->GetArrayLength(hwAddr);
     if (hw_len > 6) hw_len = 6;
@@ -62,7 +63,7 @@ Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeInit(
     if (!ctx->raop) {
         LOGE("raop_init failed");
         android_callbacks_destroy(&ctx->cb_ctx, env);
-        free(ctx);
+        delete ctx;
         return 0;
     }
     ctx->cb_ctx.raop = ctx->raop;
@@ -106,6 +107,11 @@ Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeInit(
 
     env->ReleaseStringUTFChars(keyFile, keyfile_c);
     env->ReleaseStringUTFChars(name, name_c);
+
+    ctx->log = std::make_shared<LogSink>();
+    ctx->log->bind(env, callback);
+
+    ctx->cb_ctx.audio_engine = audio_engine_create(ctx->log, 44100, 2);
 
     return (jlong)(intptr_t)ctx;
 }
@@ -168,12 +174,16 @@ Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeDestroy(
         raop_destroy(ctx->raop);
         ctx->raop = NULL;
     }
+    // engine teardown safe: raop_destroy() already ran, no decode() calls in flight
+    AudioEngine *engine = ctx->cb_ctx.audio_engine;
+    ctx->cb_ctx.audio_engine = NULL;
+    if (engine) audio_engine_destroy(engine);
     if (ctx->dnssd) {
         dnssd_destroy(ctx->dnssd);
         ctx->dnssd = NULL;
     }
     android_callbacks_destroy(&ctx->cb_ctx, env);
-    free(ctx);
+    delete ctx;
 }
 
 extern "C"
@@ -333,91 +343,67 @@ Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeUpdatePlaybackInfo(
     android_callbacks_update_playback_info(&ctx->cb_ctx, position, duration, rate, readyToPlay ? 1 : 0);
 }
 
-/* ---------- Software ALAC decoder (Apple reference, Apache 2.0) ---------- */
-
 extern "C"
-JNIEXPORT jlong JNICALL
-Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeAlacInit(
-        JNIEnv *env, jobject thiz,
-        jint frameLength, jint numChannels, jint bitDepth,
-        jint pb, jint mb, jint kb) {
-
-    ALACDecoder *dec = new ALACDecoder();
-    if (!dec) return 0;
-
-    /* Build the 24-byte ALACSpecificConfig (big-endian) */
-    uint8_t cookie[24];
-    cookie[0] = (frameLength >> 24) & 0xFF;
-    cookie[1] = (frameLength >> 16) & 0xFF;
-    cookie[2] = (frameLength >> 8) & 0xFF;
-    cookie[3] = frameLength & 0xFF;
-    cookie[4] = 0;                /* compatibleVersion */
-    cookie[5] = (uint8_t)bitDepth;
-    cookie[6] = (uint8_t)pb;
-    cookie[7] = (uint8_t)mb;
-    cookie[8] = (uint8_t)kb;
-    cookie[9] = (uint8_t)numChannels;
-    cookie[10] = 0; cookie[11] = 0xFF; /* maxRun = 255 (big-endian) */
-    cookie[12] = cookie[13] = cookie[14] = cookie[15] = 0; /* maxFrameBytes */
-    cookie[16] = cookie[17] = cookie[18] = cookie[19] = 0; /* avgBitRate */
-    cookie[20] = 0; cookie[21] = 0;                        /* sampleRate 44100 */
-    cookie[22] = 0xAC; cookie[23] = 0x44;                  /* (big-endian) */
-
-    int32_t status = dec->Init(cookie, sizeof(cookie));
-    if (status != 0) {
-        LOGE("ALACDecoder::Init failed: %d", status);
-        delete dec;
-        return 0;
-    }
-    LOGI("ALACDecoder initialized: %dx%d @%d-bit", frameLength, numChannels, bitDepth);
-    return (jlong)(intptr_t)dec;
+JNIEXPORT void JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeSetDefaultStreamValues(
+        JNIEnv *env, jobject thiz, jint sampleRate, jint framesPerBurst) {
+    audio_engine_set_default_stream_values(sampleRate, framesPerBurst);
 }
 
 extern "C"
-JNIEXPORT jbyteArray JNICALL
-Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeAlacDecode(
-        JNIEnv *env, jobject thiz, jlong handle, jbyteArray input) {
-
-    ALACDecoder *dec = (ALACDecoder *)(intptr_t)handle;
-    if (!dec || !input) return NULL;
-
-    int input_len = env->GetArrayLength(input);
-    jbyte *input_data = env->GetByteArrayElements(input, NULL);
-
-    /* Set up BitBuffer for the Apple decoder */
-    BitBuffer bits;
-    BitBufferInit(&bits, (uint8_t *)input_data, input_len);
-
-    uint32_t numFrames = dec->mConfig.frameLength;
-    uint32_t numChannels = dec->mConfig.numChannels;
-    uint32_t outBytes = numFrames * numChannels * (dec->mConfig.bitDepth / 8);
-    uint8_t *pcm = (uint8_t *)calloc(outBytes, 1);
-    if (!pcm) {
-        env->ReleaseByteArrayElements(input, input_data, JNI_ABORT);
-        return NULL;
-    }
-
-    uint32_t outSamples = 0;
-    int32_t status = dec->Decode(&bits, pcm, numFrames, numChannels, &outSamples);
-    env->ReleaseByteArrayElements(input, input_data, JNI_ABORT);
-
-    if (status != 0 || outSamples == 0) {
-        free(pcm);
-        return NULL;
-    }
-
-    int pcm_bytes = outSamples * numChannels * (dec->mConfig.bitDepth / 8);
-    jbyteArray result = env->NewByteArray(pcm_bytes);
-    env->SetByteArrayRegion(result, 0, pcm_bytes, (jbyte *)pcm);
-    free(pcm);
-    return result;
+JNIEXPORT jboolean JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeServerAudioStart(
+        JNIEnv *env, jobject thiz, jlong handle) {
+    server_ctx_t *ctx = (server_ctx_t *)(intptr_t)handle;
+    if (!ctx || !ctx->cb_ctx.audio_engine) return JNI_FALSE;
+    return audio_engine_start(ctx->cb_ctx.audio_engine) ? JNI_TRUE : JNI_FALSE;
 }
 
 extern "C"
 JNIEXPORT void JNICALL
-Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeAlacDestroy(
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeServerAudioStop(
         JNIEnv *env, jobject thiz, jlong handle) {
+    server_ctx_t *ctx = (server_ctx_t *)(intptr_t)handle;
+    if (ctx && ctx->cb_ctx.audio_engine) audio_engine_pause(ctx->cb_ctx.audio_engine);
+}
 
-    ALACDecoder *dec = (ALACDecoder *)(intptr_t)handle;
-    delete dec;
+extern "C"
+JNIEXPORT jboolean JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeServerAudioConfigure(
+        JNIEnv *env, jobject thiz, jlong handle, jint cushionMs, jint percentilePct,
+        jint oboeBufferFrames, jboolean forceSwAlac, jboolean realtimePriority, jboolean lowLatency,
+        jboolean benchmarkLog) {
+    server_ctx_t *ctx = (server_ctx_t *)(intptr_t)handle;
+    if (!ctx || !ctx->cb_ctx.audio_engine) return JNI_FALSE;
+    return audio_engine_configure(ctx->cb_ctx.audio_engine, cushionMs, percentilePct,
+                                  oboeBufferFrames, forceSwAlac, realtimePriority, lowLatency,
+                                  benchmarkLog) ? JNI_TRUE : JNI_FALSE;
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeServerAudioSetVolume(
+        JNIEnv *env, jobject thiz, jlong handle, jfloat volume) {
+    server_ctx_t *ctx = (server_ctx_t *)(intptr_t)handle;
+    if (ctx && ctx->cb_ctx.audio_engine) audio_engine_set_volume(ctx->cb_ctx.audio_engine, volume);
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeServerAudioFormat(
+        JNIEnv *env, jobject thiz, jlong handle, jint ct, jint spf) {
+    server_ctx_t *ctx = (server_ctx_t *)(intptr_t)handle;
+    if (ctx && ctx->cb_ctx.audio_engine) audio_engine_on_format(ctx->cb_ctx.audio_engine, ct, spf);
+}
+
+extern "C"
+JNIEXPORT jboolean JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeServerAudioDebug(
+        JNIEnv *env, jobject thiz, jlong handle, jobject buf) {
+    server_ctx_t *ctx = (server_ctx_t *)(intptr_t)handle;
+    if (!ctx || !ctx->cb_ctx.audio_engine || !buf) return JNI_FALSE;
+    void *addr = env->GetDirectBufferAddress(buf);
+    jlong cap = env->GetDirectBufferCapacity(buf);
+    if (!addr || cap <= 0) return JNI_FALSE;
+    return audio_engine_get_debug(ctx->cb_ctx.audio_engine, addr, (size_t)cap) ? JNI_TRUE : JNI_FALSE;
 }

--- a/app/src/main/cpp/timeline_buffer.h
+++ b/app/src/main/cpp/timeline_buffer.h
@@ -1,0 +1,382 @@
+#ifndef TIMELINE_BUFFER_H
+#define TIMELINE_BUFFER_H
+
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <string>
+
+#include "audio_time.h"
+
+/*
+ * lock-free SPSC ring of int16 samples (interleaved frames); positions are
+ * non-wrapping 64-bit counters so empty/full are unambiguous without spare slot
+ */
+class SpscRing {
+public:
+    explicit SpscRing(size_t capacitySamples)
+        : mCapacity(capacitySamples), mBuf(new int16_t[capacitySamples]) {}
+
+    size_t available() const {  // samples readable
+        return mWrite.load(std::memory_order_acquire) - mRead.load(std::memory_order_acquire);
+    }
+
+    // producer: push up to n samples, drops what doesn't fit
+    size_t write(const int16_t *src, size_t n) {
+        const size_t w = mWrite.load(std::memory_order_relaxed);
+        const size_t r = mRead.load(std::memory_order_acquire);
+        const size_t freeSpace = mCapacity - (w - r);
+        if (n > freeSpace) n = freeSpace;
+        const size_t wi = w % mCapacity;
+        const size_t first = (n < mCapacity - wi) ? n : (mCapacity - wi);
+        memcpy(&mBuf[wi], src, first * sizeof(int16_t));
+        if (n > first) memcpy(&mBuf[0], src + first, (n - first) * sizeof(int16_t));
+        mWrite.store(w + n, std::memory_order_release);
+        return n;
+    }
+
+    // consumer: pop up to n samples
+    size_t read(int16_t *dst, size_t n) {
+        const size_t r = mRead.load(std::memory_order_relaxed);
+        const size_t w = mWrite.load(std::memory_order_acquire);
+        const size_t avail = w - r;
+        if (n > avail) n = avail;
+        const size_t ri = r % mCapacity;
+        const size_t first = (n < mCapacity - ri) ? n : (mCapacity - ri);
+        memcpy(dst, &mBuf[ri], first * sizeof(int16_t));
+        if (n > first) memcpy(dst + first, &mBuf[0], (n - first) * sizeof(int16_t));
+        mRead.store(r + n, std::memory_order_release);
+        return n;
+    }
+
+    // consumer: discard up to n oldest samples
+    void skip(size_t n) {
+        const size_t r = mRead.load(std::memory_order_relaxed);
+        const size_t w = mWrite.load(std::memory_order_acquire);
+        const size_t avail = w - r;
+        if (n > avail) n = avail;
+        mRead.store(r + n, std::memory_order_release);
+    }
+
+private:
+    const size_t mCapacity;
+    std::unique_ptr<int16_t[]> mBuf;
+    std::atomic<size_t> mWrite{0};
+    std::atomic<size_t> mRead{0};
+};
+
+/*
+ * adaptive jitter cushion tuner, NetEQ-inspired but simplified: decaying histogram of
+ * packet jitter, cushion = high percentile of it + 1 packet of margin.
+ * observe() is producer-thread only; result published via atomic, consumer reads it live
+ */
+class DelayTracker {
+public:
+    // staticCushionMs > 0: fixed cushion, tuner disabled
+    // staticCushionMs <= 0: tune between MIN_CUSHION_MS and MAX_CUSHION_MS
+    DelayTracker(int sampleRate, int channels, int staticCushionMs, int percentilePct)
+        : mSampleRate(sampleRate), mChannels(channels),
+          mAdaptive(staticCushionMs <= 0),
+          mFloor(msToSamples(sampleRate, channels, mAdaptive ? MIN_CUSHION_MS : staticCushionMs)),
+          mCeil(msToSamples(sampleRate, channels, mAdaptive ? MAX_CUSHION_MS : staticCushionMs)),
+          mPercentilePct(percentilePct),
+          mTuned(mFloor) {}
+
+    // ptsNs: packet presentation time; arrivalNs: local arrival time; durNs: packet duration
+    void observe(int64_t ptsNs, int64_t arrivalNs, int64_t durNs) {
+        if (!mAdaptive) return;
+
+        const int64_t raw = arrivalNs - ptsNs; // arrival latency
+        // jitter = latency relative to min latency seen so far (mBaseNs)
+        if (!mHaveBase) { mBaseNs = raw; mHaveBase = true; }
+        else if (raw < mBaseNs) mBaseNs = raw;
+        // creep mBaseNs up slowly: counters clock drift and one freak fast packet
+        else mBaseNs += (raw - mBaseNs) >> BASE_CREEP_SHIFT;
+        int64_t rel = raw - mBaseNs;
+        if (rel < 0) rel = 0;
+
+        int bin = (int)(rel / BUCKET_NS);
+        if (bin >= NBUCKETS) bin = NBUCKETS - 1;
+
+        // decay: each bin bleeds 1/2^FORGET_SHIFT per packet, current bin topped up by
+        // ONE/2^FORGET_SHIFT, so total converges to ONE
+        int64_t sum = 0;
+        for (int i = 0; i < NBUCKETS; i++) {
+            mHist[i] -= (mHist[i] + (1 << FORGET_SHIFT) - 1) >> FORGET_SHIFT;
+            sum += mHist[i];
+        }
+        mHist[bin] += ONE >> FORGET_SHIFT;
+        sum += ONE >> FORGET_SHIFT;
+
+        // cushion = smallest delay whose cumulative histogram share reaches percentile
+        const int64_t thresh = sum * mPercentilePct / 100;
+        int64_t cum = 0; int b = 0;
+        for (; b < NBUCKETS - 1; b++) { cum += mHist[b]; if (cum >= thresh) break; }
+        // bin is lower bound on delay: take top edge + margin. margin must keep output
+        // fed for one data callback and tide us over until next packet
+        const int64_t marginNs = std::max(durNs, mOutputBufferNs.load(std::memory_order_relaxed));
+        const int64_t targetNs = (int64_t)(b + 1) * BUCKET_NS + marginNs;
+        size_t samples = (size_t)(targetNs * mSampleRate / NS_PER_SEC) * mChannels;
+        if (samples < mFloor) samples = mFloor;
+        if (samples > mCeil) samples = mCeil;
+        mTuned.store(samples, std::memory_order_relaxed);
+    }
+
+    // reset clock base after discontinuity or clock shift/resync so it doesn't poison
+    // jitter calculations; producer-thread only (same as observe())
+    void reanchor() { mHaveBase = false; }
+
+    // latest tuned cushion in samples; any thread
+    size_t target() const { return mTuned.load(std::memory_order_relaxed); }
+
+    void noteOutputBufferFrames(int frames) {
+        mOutputBufferNs.store((int64_t)frames * NS_PER_SEC / mSampleRate, std::memory_order_relaxed);
+    }
+
+    // largest cushion tuner can reach, in samples
+    size_t ceil() const { return mCeil; }
+
+private:
+    static size_t msToSamples(int sampleRate, int channels, int ms) {
+        return (size_t)sampleRate * ms / 1000 * channels;
+    }
+
+    static constexpr int MIN_CUSHION_MS = 0;             // algorithm already enforces effective floor
+    static constexpr int MAX_CUSHION_MS = 1000;
+    static constexpr int BUCKET_MS = 5;                  // histogram granularity
+    static constexpr int NBUCKETS = MAX_CUSHION_MS / BUCKET_MS;
+    static constexpr int64_t BUCKET_NS = (int64_t)BUCKET_MS * 1000000LL;
+    static constexpr int FORGET_SHIFT = 8;               // ~1/256 decay per packet (~6s @ 23ms)
+    static constexpr int BASE_CREEP_SHIFT = 10;          // mBaseNs creep speed
+    static constexpr int64_t ONE = 1 << 20;              // histogram fixed-point unit
+
+    const int mSampleRate;
+    const int mChannels;
+    const bool mAdaptive;                // false = fixed cushion (tuner disabled)
+    const size_t mFloor;
+    const size_t mCeil;
+    const int mPercentilePct;            // arrival-delay percentile cushion targets
+    std::atomic<size_t> mTuned;
+    std::atomic<int64_t> mOutputBufferNs{0};  // output->producer: oboe output buffer duration
+    int64_t mHist[NBUCKETS] = {};
+    int64_t mBaseNs = 0;
+    bool mHaveBase = false;
+};
+
+// cumulative diagnostic counters, bumped from producer/consumer, read from stats thread
+class TimelineMetrics {
+public:
+    // packed: nests into AudioDebugData with fixed layout
+    struct __attribute__((packed)) Debug {
+        uint32_t trims, drops, silences, underruns;  // cumulative; 32-bit to avoid wrap
+    };
+
+    void countTrim()     { mTrims.fetch_add(1, std::memory_order_relaxed); }
+    void countDrop()     { mDrops.fetch_add(1, std::memory_order_relaxed); }
+    void countSilence()  { mSilences.fetch_add(1, std::memory_order_relaxed); }
+    void countUnderrun() { mUnderruns.fetch_add(1, std::memory_order_relaxed); }
+
+    // any thread
+    Debug debugInfo() const {
+        Debug d{};
+        d.trims = mTrims.load(std::memory_order_relaxed);
+        d.drops = mDrops.load(std::memory_order_relaxed);
+        d.silences = mSilences.load(std::memory_order_relaxed);
+        d.underruns = mUnderruns.load(std::memory_order_relaxed);
+        return d;
+    }
+
+private:
+    std::atomic<uint32_t> mTrims{0};      // backlog exceeded cap and was trimmed
+    std::atomic<uint32_t> mDrops{0};      // late packets dropped, pts slot already passed
+    std::atomic<uint32_t> mSilences{0};   // gaps filled with silence
+    std::atomic<uint32_t> mUnderruns{0};  // ring ran dry, output padded with silence
+};
+
+/*
+ * Timeline-synchronized playout buffer: absorbs jitter, clock drift and clock resyncs,
+ * syncs audio to its presentation-time tag.
+ *
+ * One concurrent reader + one concurrent writer OK; multiple readers or writers NOT safe.
+ * samples = frames * channels
+ */
+class TimelineBuffer {
+public:
+    // cushion policy lives in mTracker; timeline reads mTracker.target() live
+    TimelineBuffer(int sampleRate, int channels, int staticCushionMs, int percentilePct)
+        : mSampleRate(sampleRate),
+          mChannels(channels),
+          mTracker(sampleRate, channels, staticCushionMs, percentilePct),
+          // ring can't be reallocated mid-stream: size for worst-case backlog, i.e. cap
+          // of largest reachable cushion + one throttle window of overshoot (trims are
+          // throttled), 2x slack
+          mRing(2 * capOf(mTracker.ceil()) + (size_t)sampleRate * TRIM_THROTTLE_MS / 1000 * channels) {}
+
+    void noteOutputBufferFrames(int frames) { mTracker.noteOutputBufferFrames(frames); }
+
+    // producer: push samples
+    void write(const int16_t *pcm, size_t samples, int64_t ptsNs) {
+        if (samples == 0) return;
+        const int64_t durNs = samples * NS_PER_SEC / mChannels / mSampleRate;
+
+        // consumer underran since last write: it already played the gap as real-time
+        // silence, re-anchor so we don't also insert it here
+        if (mUnderran.exchange(false, std::memory_order_relaxed)) {
+            mExpectedPtsNs = ptsNs;
+        }
+        const int64_t gapNs = ptsNs - mExpectedPtsNs;
+
+        // large gap: possible discontinuity or clock shift. reanchor() must precede
+        // observe() so the reset applies to this observation
+        if (gapNs > MAX_GAP_NS || gapNs < -MAX_GAP_NS) mTracker.reanchor();
+
+        // no-op in static-cushion mode
+        mTracker.observe(ptsNs, monoNs(), durNs);
+
+        if (gapNs > MAX_GAP_NS || gapNs < -MAX_GAP_NS) {
+            // discontinuity: write immediately. new sound after long silence resets
+            // backlog to ideal size (less latency); on clock resync we keep the sound
+        } else if (gapNs > SLACK_NS) {
+            // sender left gap: reproduce as silence so timing is exact
+            const size_t silenceFrames = (size_t)(gapNs * mSampleRate / NS_PER_SEC);
+            writeSilenceFrames(silenceFrames);
+            mMetrics.countSilence();
+        } else if (gapNs < -SLACK_NS) {
+            // slot already passed (late/overlap): drop
+            mMetrics.countDrop();
+            return;
+        }
+        mRing.write(pcm, samples);
+        mExpectedPtsNs = ptsNs + durNs;
+    }
+
+    // consumer: pop frames*channels samples into out, silence-padded on underrun
+    void read(int16_t *out, int32_t frames) {
+        const size_t need = (size_t)frames * mChannels;
+        const size_t tuned = mTracker.target();
+        const int64_t now = monoNs();
+
+        // bound latency: cap tracks tuned cushion live so a calmed link sheds latency
+        // without an underrun. each trim costs a glitch, so be conservative: trim only
+        // after backlog stayed above cap for TRIM_SUSTAIN (skip transient spikes), at
+        // most once per TRIM_THROTTLE, and not within that window of an underrun
+        // (trimming while rebuilding cushion is counterproductive)
+        const size_t avail = mRing.available();
+        if (avail > capOf(tuned)) {
+            if (mAboveCapSinceNs == 0) mAboveCapSinceNs = now;
+        } else {
+            mAboveCapSinceNs = 0;
+        }
+        if (mAboveCapSinceNs != 0 && now - mAboveCapSinceNs >= TRIM_SUSTAIN_NS
+                && now - mLastTrimBlockNs >= TRIM_THROTTLE_NS) {
+            mRing.skip(avail - tuned);
+            mMetrics.countTrim();
+            mLastTrimBlockNs = now;
+            mAboveCapSinceNs = 0;
+        }
+
+        // prebuffer: hold output until cushion fills, builds jitter headroom
+        if (mPriming) {
+            const size_t buffered = mRing.available();
+            // time the wait only while holding partial data; reset on empty ring so the
+            // producer gets the full window once a sound starts, otherwise we could time
+            // out on pre-sound silence and underrun the instant the first frame lands
+            if (buffered == 0) mPrimeSilenceFrames = 0;
+            else mPrimeSilenceFrames += (uint32_t)frames;
+            // short sound can end before filling cushion; after holding partial data
+            // through 2x cushion of silence the sound is complete: play it
+            const uint32_t starveFrames = (uint32_t)(2 * tuned / mChannels);
+            const bool starved = buffered > 0 && mPrimeSilenceFrames >= starveFrames;
+            // also keep priming on empty ring: with 0 cushion `buffered < tuned` is
+            // never true, so we'd otherwise underrun on every empty read between sounds
+            if (buffered == 0 || (buffered < tuned && !starved)) {
+                memset(out, 0, need * sizeof(int16_t));
+                return;
+            }
+            mPriming = false;
+            mPrimeSilenceFrames = 0;
+        }
+
+        const size_t got = mRing.read(out, need);
+        if (got < need) {
+            memset(out + got, 0, (need - got) * sizeof(int16_t));
+            mPriming = true;
+            mLastTrimBlockNs = now;  // hold off trims while rebuilding
+            mUnderran.store(true, std::memory_order_relaxed);  // producer re-anchors
+            mMetrics.countUnderrun();
+        }
+    }
+
+    // call after discontinuity or clock shift/resync; producer-side, must not run
+    // concurrently with write()
+    void reanchorTracker() { mTracker.reanchor(); }
+
+    // rebuild prebuffer cushion before resuming, e.g. after output stream restart;
+    // must not run concurrently with read()
+    void reprime() { mPriming = true; }
+
+    // drop buffered audio + rebuild cushion, so resume after pause doesn't play stale
+    // tail; only while output callback is stopped (skip() is consumer-side)
+    void flushAndReprime() {
+        mRing.skip(mRing.available());
+        mPriming = true;
+    }
+
+    // debug snapshot: backlog + tuned cushion (ms) + counters; reads only atomics, any thread
+    struct __attribute__((packed)) Debug {
+        uint16_t backlogMs;         // bounded by ring (few seconds)
+        uint16_t tunedCushionMs;    // bounded by MAX_CUSHION_MS
+        TimelineMetrics::Debug metrics;
+    };
+    Debug debugInfo() const {
+        Debug d{};
+        d.backlogMs = (uint16_t)(mRing.available() / mChannels * 1000 / mSampleRate);
+        d.tunedCushionMs = (uint16_t)(mTracker.target() / mChannels * 1000 / mSampleRate);
+        d.metrics = mMetrics.debugInfo();
+        return d;
+    }
+
+private:
+
+    // latency ceiling for cushion: 2x, but never below TRIM_FLOOR_MS so tiny cushion
+    // still gets slack before a trim (trim costs a glitch)
+    size_t capOf(size_t cushionSamples) const {
+        return std::max(cushionSamples * 2, (size_t)mSampleRate * TRIM_FLOOR_MS / 1000 * mChannels);
+    }
+
+    void writeSilenceFrames(size_t frames) {
+        int16_t zeros[512] = {0};  // 256 stereo frames per chunk
+        size_t samples = frames * mChannels;
+        while (samples > 0) {
+            const size_t n = std::min<size_t>(samples, 512);
+            mRing.write(zeros, n);
+            samples -= n;
+        }
+    }
+
+    static constexpr int64_t SLACK_NS = 10'000'000LL;    // ignore <10ms gaps (NTP shift, rounding)
+    static constexpr int64_t MAX_GAP_NS = 750'000'000LL; // >750ms = discontinuity, re-anchor
+    static constexpr int TRIM_FLOOR_MS = 30;             // min trim point even for tiny cushion
+    static constexpr int TRIM_THROTTLE_MS = 2000;        // min spacing between trims, and after underrun
+    static constexpr int64_t TRIM_THROTTLE_NS = (int64_t)TRIM_THROTTLE_MS * 1'000'000LL;
+    static constexpr int TRIM_SUSTAIN_MS = 2000;         // backlog must exceed cap this long before trim
+    static constexpr int64_t TRIM_SUSTAIN_NS = (int64_t)TRIM_SUSTAIN_MS * 1'000'000LL;
+
+    const int mSampleRate;
+    const int mChannels;
+    DelayTracker mTracker;               // owns cushion policy; read live each read()
+    SpscRing mRing;
+    TimelineMetrics mMetrics;
+    bool mPriming = true;                // stream start: buffer output to build cushion
+    uint32_t mPrimeSilenceFrames = 0;    // consumer-only: silence frames output while priming with partial data
+    int64_t mLastTrimBlockNs = 0;        // consumer-only: last trim/underrun time (trim throttle)
+    int64_t mAboveCapSinceNs = 0;        // consumer-only: when backlog first exceeded cap (0 = under)
+    std::atomic<bool> mUnderran{false};  // consumer->producer: underrun happened
+
+    int64_t mExpectedPtsNs = 0;          // presentation time expected at write head
+};
+
+#endif  // TIMELINE_BUFFER_H

--- a/app/src/main/kotlin/io/github/jqssun/airplay/Prefs.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/Prefs.kt
@@ -16,10 +16,18 @@ object Prefs {
     val KEY_ALLOW_FRAME_DROP: String = MediaFormat.KEY_ALLOW_FRAME_DROP; const val DEF_KEY_ALLOW_FRAME_DROP = true
     val KEY_PRIORITY: String = MediaFormat.KEY_PRIORITY; const val DEF_KEY_PRIORITY = true
     val KEY_OPERATING_RATE: String = MediaFormat.KEY_OPERATING_RATE; const val DEF_KEY_OPERATING_RATE = true
+    const val LOW_LATENCY = "low_latency"; const val DEF_LOW_LATENCY = true
     const val SCHEDULED_OUTPUT_BUFFER_RELEASE = "scheduled_output_buffer_release"; const val DEF_SCHEDULED_OUTPUT_BUFFER_RELEASE = false
-    const val AUDIO_BUFFER_MULTIPLIER = "audio_buffer_multiplier"; const val DEF_AUDIO_BUFFER_MULTIPLIER = 4
+    const val AUDIO_AUTO_BUFFER = "audio_auto_buffer"; const val DEF_AUDIO_AUTO_BUFFER = true
+    // fixed cushion ms, used only when AUDIO_AUTO_BUFFER is off
+    const val AUDIO_CUSHION_MS = "audio_cushion_ms"; const val DEF_AUDIO_CUSHION_MS = 40
+    // slider step 0..4 mapping to arrival-delay percentile the cushion targets;
+    // lower = less latency, higher = more stable
+    const val AUDIO_ADAPTIVE_STEP = "audio_adaptive_step"; const val DEF_AUDIO_ADAPTIVE_STEP = 3
+    val ADAPTIVE_PERCENTILES = intArrayOf(80, 85, 90, 95, 99)
+    const val OBOE_BUFFER_FRAMES = "oboe_buffer_frames"; const val DEF_OBOE_BUFFER_FRAMES = 0
     const val ALAC_ENABLED = "alac_enabled"; const val DEF_ALAC_ENABLED = false
-    const val SW_ALAC_ENABLED = "sw_alac_enabled"; const val DEF_SW_ALAC_ENABLED = true
+    const val FORCE_SW_ALAC = "force_sw_alac"; const val DEF_FORCE_SW_ALAC = false
     const val AAC_ENABLED = "aac_enabled"; const val DEF_AAC_ENABLED = true
     const val RESOLUTION = "resolution"; const val DEF_RESOLUTION = "auto"
     const val MAX_FPS = "max_fps"; const val DEF_MAX_FPS = 60

--- a/app/src/main/kotlin/io/github/jqssun/airplay/bridge/LogListener.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/bridge/LogListener.kt
@@ -1,0 +1,9 @@
+package io.github.jqssun.airplay.bridge
+
+/**
+ * log lines from native code, forwarded to UI; called directly from native threads
+ * (attached to JVM for the call), implementations must be thread-safe and cheap
+ */
+interface LogListener {
+    fun onLog(msg: String)
+}

--- a/app/src/main/kotlin/io/github/jqssun/airplay/bridge/NativeBridge.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/bridge/NativeBridge.kt
@@ -33,9 +33,15 @@ object NativeBridge {
     external fun nativeGetRaopServiceName(handle: Long): String?
     external fun nativeGetServerName(handle: Long): String?
 
-    // software alac decoder
-    external fun nativeAlacInit(frameLength: Int, numChannels: Int, bitDepth: Int,
-                                pb: Int, mb: Int, kb: Int): Long
-    external fun nativeAlacDecode(handle: Long, input: ByteArray): ByteArray?
-    external fun nativeAlacDestroy(handle: Long)
+    external fun nativeSetDefaultStreamValues(sampleRate: Int, framesPerBurst: Int)
+    external fun nativeServerAudioConfigure(handle: Long, cushionMs: Int, percentilePct: Int,
+                                            oboeBufferFrames: Int, forceSwAlac: Boolean,
+                                            realtimePriority: Boolean, lowLatency: Boolean,
+                                            benchmarkLog: Boolean): Boolean
+    external fun nativeServerAudioStart(handle: Long): Boolean
+    external fun nativeServerAudioStop(handle: Long)
+    external fun nativeServerAudioSetVolume(handle: Long, volume: Float)
+    external fun nativeServerAudioFormat(handle: Long, ct: Int, spf: Int)
+    // fills direct buffer with packed debug snapshot; false if audio isn't running
+    external fun nativeServerAudioDebug(handle: Long, buf: java.nio.ByteBuffer): Boolean
 }

--- a/app/src/main/kotlin/io/github/jqssun/airplay/bridge/RaopCallbackHandler.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/bridge/RaopCallbackHandler.kt
@@ -2,7 +2,6 @@ package io.github.jqssun.airplay.bridge
 
 interface RaopCallbackHandler {
     fun onVideoData(data: ByteArray, ntpTimeNs: Long, isH265: Boolean)
-    fun onAudioData(data: ByteArray, ct: Int, ntpTimeNs: Long, seqNum: Int)
     fun onAudioFormat(ct: Int, spf: Int, usingScreen: Boolean)
     fun onVideoSize(srcW: Float, srcH: Float, w: Float, h: Float)
     fun onVolumeChange(volume: Float)

--- a/app/src/main/kotlin/io/github/jqssun/airplay/renderer/AudioConfig.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/renderer/AudioConfig.kt
@@ -1,0 +1,15 @@
+package io.github.jqssun.airplay.renderer
+
+/**
+ * mirrors native AudioConfig struct; defaults must match preference defaults so a
+ * freshly-constructed AudioRenderer is sane
+ */
+data class AudioConfig(
+    val cushionMs: Int = 0,           // 0 = adaptive tuner, otherwise fixed cushion ms
+    val percentilePct: Int = 95,
+    val oboeBufferFrames: Int = 0,    // 0 = auto (two bursts)
+    val forceSwAlac: Boolean = false,
+    val realtimePriority: Boolean = true,
+    val lowLatency: Boolean = true,
+    val benchmarkLog: Boolean = false,
+)

--- a/app/src/main/kotlin/io/github/jqssun/airplay/renderer/AudioRenderer.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/renderer/AudioRenderer.kt
@@ -1,224 +1,107 @@
 package io.github.jqssun.airplay.renderer
 
-import android.media.AudioAttributes
-import android.media.AudioFormat
-import android.media.AudioTrack
-import android.media.MediaCodec
-import android.media.MediaFormat
-import android.util.Log
 import io.github.jqssun.airplay.bridge.NativeBridge
-import java.nio.ByteBuffer
+import io.github.jqssun.airplay.viewmodel.AudioDebug
 import kotlin.math.pow
 
+// wrapper around native audio engine
 class AudioRenderer {
 
-    private var codec: MediaCodec? = null
-    private var track: AudioTrack? = null
-    private var currentCt = -1
-    private var failedCt = -1
-    private var swAlacHandle = 0L  // software ALAC decoder handle
-    @Volatile var swAlacEnabled = true
-    @Volatile var audioBufferMultiplier = 4
-    @Volatile var realtimeDecoderPriority = true
+    @Volatile var config = AudioConfig(); private set
+
     @Volatile var volume = 1.0f; private set
     @Volatile var codecLabel = ""; private set
-    @Volatile private var pendingReset = false
 
-    fun markSessionEnded() { pendingReset = true }
+    private var serverHandle = 0L
 
-    fun feedAudio(data: ByteArray, ct: Int, ntpTimeNs: Long) {
-        if (pendingReset) {
-            pendingReset = false
-            stop()
-        }
-        if (ct != currentCt || (codec == null && swAlacHandle == 0L)) {
-            if (ct == failedCt) {
-                if (!_ensureSoftwareAlac(ct)) return
-            } else {
-                stop()
-                start(ct)
-            }
-        }
-
-        // software alac path
-        if (swAlacHandle != 0L && ct == CT_ALAC) {
-            _feedSoftwareAlac(data)
-            return
-        }
-
-        // MediaCodec path
-        val c = codec ?: return
-        try {
-            val idx = c.dequeueInputBuffer(5000)
-            if (idx >= 0) {
-                val buf = c.getInputBuffer(idx) ?: return
-                buf.clear()
-                buf.put(data)
-                c.queueInputBuffer(idx, 0, data.size, ntpTimeNs / 1000, 0)
-            }
-            drainOutput()
-        } catch (_: IllegalStateException) {
-            codec = null
-            failedCt = ct
-            if (_ensureSoftwareAlac(ct)) _feedSoftwareAlac(data)
-        }
+    @Synchronized
+    fun attachEngine(server: Long) {
+        serverHandle = server
+        pushConfig()
+        NativeBridge.nativeServerAudioSetVolume(serverHandle, volume)
     }
 
-    /** Try to start software ALAC if applicable. Returns true if SW decoder is ready. */
-    private fun _ensureSoftwareAlac(ct: Int): Boolean {
-        if (ct != CT_ALAC || !swAlacEnabled) return false
-        if (swAlacHandle != 0L) return true
-        _startSoftwareAlac()
-        return swAlacHandle != 0L
+    @Synchronized
+    fun detachEngine() {
+        serverHandle = 0L
+        codecLabel = ""
     }
 
-    private fun _feedSoftwareAlac(data: ByteArray) {
-        val pcm = NativeBridge.nativeAlacDecode(swAlacHandle, data) ?: return
-        track?.write(pcm, 0, pcm.size)
+    // open playout (first onAudioFormat, or resume after pause); idempotent natively
+    @Synchronized
+    fun start() {
+        if (serverHandle == 0L) return
+        NativeBridge.nativeServerAudioStart(serverHandle)
     }
 
-    private fun _startSoftwareAlac() {
-        Log.i(TAG, "Starting software ALAC decoder")
-        swAlacHandle = NativeBridge.nativeAlacInit(352, 2, 16, 40, 10, 14)
-        if (swAlacHandle == 0L) {
-            Log.e(TAG, "Failed to init software ALAC decoder")
-            return
-        }
-        currentCt = CT_ALAC
-        codecLabel = "ALAC (SW)"
-        _ensureAudioTrack()
+    // releases oboe stream + audio device while idle; engine stays alive, freed on server destroy
+    @Synchronized
+    fun stop() {
+        if (serverHandle == 0L) return
+        NativeBridge.nativeServerAudioStop(serverHandle)
+        codecLabel = ""
     }
 
-    private fun start(ct: Int) {
-        currentCt = ct
-        codecLabel = when (ct) { CT_ALAC -> "ALAC"; CT_AAC_LC -> "AAC-LC"; CT_AAC_ELD -> "AAC-ELD"; else -> "?" }
-        val format = when (ct) {
-            CT_AAC_ELD -> {
-                MediaFormat.createAudioFormat(MediaFormat.MIMETYPE_AUDIO_AAC, 44100, 2).apply {
-                    setInteger(MediaFormat.KEY_AAC_PROFILE, 39)
-                    setInteger(MediaFormat.KEY_IS_ADTS, 0)
-                    setByteBuffer("csd-0", ByteBuffer.wrap(byteArrayOf(0xF8.toByte(), 0xE8.toByte(), 0x50, 0x00)))
-                }
-            }
-            CT_AAC_LC -> {
-                MediaFormat.createAudioFormat(MediaFormat.MIMETYPE_AUDIO_AAC, 44100, 2).apply {
-                    setInteger(MediaFormat.KEY_AAC_PROFILE, 2)
-                    setInteger(MediaFormat.KEY_IS_ADTS, 0)
-                    setByteBuffer("csd-0", ByteBuffer.wrap(byteArrayOf(0x12, 0x10)))
-                }
-            }
-            CT_ALAC -> {
-                MediaFormat.createAudioFormat("audio/alac", 44100, 2).apply {
-                    setInteger(MediaFormat.KEY_SAMPLE_RATE, 44100)
-                    setInteger(MediaFormat.KEY_CHANNEL_COUNT, 2)
-                    val csd = byteArrayOf(
-                        0x00, 0x00, 0x00, 0x24,
-                        0x61, 0x6C, 0x61, 0x63,
-                        0x00, 0x00, 0x00, 0x00,
-                        0x00, 0x00, 0x01, 0x60,
-                        0x00, 0x10, 0x28, 0x0A, 0x0E, 0x02,
-                        0x00, 0xFF.toByte(),
-                        0x00, 0x00, 0x00, 0x00,
-                        0x00, 0x00, 0x00, 0x00,
-                        0x00, 0x00, 0xAC.toByte(), 0x44,
-                    )
-                    setByteBuffer("csd-0", ByteBuffer.wrap(csd))
-                }
-            }
-            else -> {
-                Log.w(TAG, "Unknown audio codec type: $ct")
-                return
-            }
-        }
-
-        if (realtimeDecoderPriority) {
-            format.setInteger(MediaFormat.KEY_PRIORITY, 0)
-        }
-
-        try {
-            codec = MediaCodec.createDecoderByType(format.getString(MediaFormat.KEY_MIME)!!).also {
-                it.configure(format, null, null, 0)
-                it.start()
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to init audio codec for ct=$ct", e)
-            codec = null
-            failedCt = ct
-            if (ct == CT_ALAC && swAlacEnabled) {
-                _startSoftwareAlac()
-                return
-            }
-            return
-        }
-
-        _ensureAudioTrack()
-        Log.i(TAG, "Audio started: ct=$ct")
+    @Synchronized
+    fun updateConfig(newConfig: AudioConfig) {
+        config = newConfig
+        pushConfig()
     }
 
-    private fun _ensureAudioTrack() {
-        if (track != null) return
-        val attrs = AudioAttributes.Builder()
-            .setUsage(AudioAttributes.USAGE_MEDIA)
-            .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
-            .build()
-        val fmt = AudioFormat.Builder()
-            .setSampleRate(44100)
-            .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
-            .setChannelMask(AudioFormat.CHANNEL_OUT_STEREO)
-            .build()
-        val bufSize = AudioTrack.getMinBufferSize(44100, AudioFormat.CHANNEL_OUT_STEREO, AudioFormat.ENCODING_PCM_16BIT)
-        track = AudioTrack(attrs, fmt, bufSize * audioBufferMultiplier.coerceIn(4, 8), AudioTrack.MODE_STREAM, 0).also {
-            it.setVolume(volume)
-            it.play()
-        }
+    private fun pushConfig() {
+        if (serverHandle == 0L) return
+        NativeBridge.nativeServerAudioConfigure(
+            serverHandle, config.cushionMs, config.percentilePct, config.oboeBufferFrames,
+            config.forceSwAlac, config.realtimePriority, config.lowLatency, config.benchmarkLog)
     }
 
-    private fun drainOutput() {
-        val c = codec ?: return
-        val t = track ?: return
-        val info = MediaCodec.BufferInfo()
-        while (true) {
-            val idx = c.dequeueOutputBuffer(info, 0)
-            if (idx >= 0) {
-                val buf = c.getOutputBuffer(idx) ?: break
-                val pcm = ByteArray(info.size)
-                buf.get(pcm)
-                t.write(pcm, 0, pcm.size)
-                c.releaseOutputBuffer(idx, false)
-            } else {
-                break
-            }
-        }
+    private val debugBuf = java.nio.ByteBuffer.allocateDirect(DEBUG_BUF_BYTES)
+        .order(java.nio.ByteOrder.LITTLE_ENDIAN)
+
+    // field order/width must mirror native packed AudioDebugData exactly
+    @Synchronized
+    fun audioDebug(): AudioDebug? {
+        if (serverHandle == 0L) return null
+        if (!NativeBridge.nativeServerAudioDebug(serverHandle, debugBuf)) return null
+        val buf = debugBuf
+        buf.rewind()
+        val backlogMs = buf.short.toInt() and 0xFFFF
+        val tunedCushionMs = buf.short.toInt() and 0xFFFF
+        val trims = buf.int
+        val drops = buf.int
+        val silences = buf.int
+        val underruns = buf.int
+        val meanUs = buf.int
+        val maxUs = buf.int
+        val held = buf.short.toInt() and 0xFFFF
+        val xrun = buf.int
+        return AudioDebug(backlogMs, tunedCushionMs, trims, drops, silences, underruns, xrun,
+                          meanUs, maxUs, held)
     }
 
+    @Synchronized
+    fun setFormat(ct: Int, spf: Int) {
+        codecLabel = when (ct) {
+            CT_ALAC -> "ALAC"; CT_AAC_LC -> "AAC-LC"; CT_AAC_ELD -> "AAC-ELD"; else -> "?"
+        }
+        if (serverHandle != 0L) NativeBridge.nativeServerAudioFormat(serverHandle, ct, spf)
+    }
+
+    @Synchronized
     fun setVolume(vol: Float) {
-        // max: 0; min: -30; mute: -144
+        // dB: max = 0, min = -30, mute = -144
         volume = when {
             vol <= -144f -> 0f
             vol >= 0f -> 1f
             else -> 10f.pow(vol / 20f)
         }
-        track?.setVolume(volume)
+        if (serverHandle == 0L) return
+        NativeBridge.nativeServerAudioSetVolume(serverHandle, volume)
     }
-
-    fun stop() {
-        track?.let { try { it.stop(); it.release() } catch (_: Exception) {} }
-        track = null
-        codec?.let { try { it.stop(); it.release() } catch (_: Exception) {} }
-        codec = null
-        if (swAlacHandle != 0L) {
-            NativeBridge.nativeAlacDestroy(swAlacHandle)
-            swAlacHandle = 0L
-        }
-        currentCt = -1
-        failedCt = -1
-        codecLabel = ""
-    }
-
-    fun release() = stop()
 
     companion object {
-        private const val TAG = "AudioRenderer"
+        // must be >= native sizeof(AudioDebugData) (34 B)
+        private const val DEBUG_BUF_BYTES = 64
         const val CT_ALAC = 2
         const val CT_AAC_LC = 4
         const val CT_AAC_ELD = 8

--- a/app/src/main/kotlin/io/github/jqssun/airplay/renderer/VideoRenderer.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/renderer/VideoRenderer.kt
@@ -27,6 +27,7 @@ class VideoRenderer {
     var enforceSdr = true
     var keyAllowFrameDrop = true
     var realtimeDecoderPriority = true
+    var lowLatency = true
     var operatingRateHint = false
     var scheduledOutputBufferRelease = true
     var benchmarkLog = false
@@ -172,6 +173,9 @@ class VideoRenderer {
         }
         if (android.os.Build.VERSION.SDK_INT >= 29) {
             format.setInteger(MediaFormat.KEY_ALLOW_FRAME_DROP, if (keyAllowFrameDrop) 1 else 0)
+        }
+        if (lowLatency && android.os.Build.VERSION.SDK_INT >= 30) {
+            format.setInteger(MediaFormat.KEY_LOW_LATENCY, 1)
         }
 
         codec = MediaCodec.createDecoderByType(mime).also {

--- a/app/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
@@ -4,13 +4,14 @@ import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
-import android.app.Service
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.SharedPreferences
 import android.content.pm.ServiceInfo
 import android.graphics.BitmapFactory
+import android.media.AudioManager
 import android.os.Binder
 import android.os.Build
 import android.os.Handler
@@ -26,6 +27,8 @@ import android.view.Surface
 import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.LifecycleService
+import androidx.lifecycle.lifecycleScope
 import androidx.media.app.NotificationCompat as MediaNotificationCompat
 import io.github.jqssun.airplay.MainActivity
 import io.github.jqssun.airplay.Prefs
@@ -34,6 +37,7 @@ import io.github.jqssun.airplay.audio.DacpController
 import io.github.jqssun.airplay.audio.DacpPlayer
 import io.github.jqssun.airplay.audio.DmapParser
 import io.github.jqssun.airplay.audio.TrackInfo
+import io.github.jqssun.airplay.bridge.LogListener
 import io.github.jqssun.airplay.bridge.NativeBridge
 import io.github.jqssun.airplay.bridge.RaopCallbackHandler
 import io.github.jqssun.airplay.discovery.NsdServiceManager
@@ -46,6 +50,8 @@ import java.net.NetworkInterface
 import kotlin.math.abs
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.launch
 
 data class VideoPlaybackInfo(
     val positionMs: Long = 0,
@@ -56,7 +62,7 @@ data class VideoPlaybackInfo(
     val buffering: Boolean = false,
 )
 
-class AirPlayService : Service(), RaopCallbackHandler {
+class AirPlayService : LifecycleService(), RaopCallbackHandler, LogListener {
 
     private var nativeHandle = 0L
     private var nsdManager: NsdServiceManager? = null
@@ -72,6 +78,9 @@ class AirPlayService : Service(), RaopCallbackHandler {
     private val _videoLocation = MutableStateFlow<String?>(null)
     val videoLocation = _videoLocation.asStateFlow()
 
+    private val prefs: SharedPreferences by lazy {
+        getSharedPreferences(Prefs.NAME, Context.MODE_PRIVATE)
+    }
     private val _serverState = MutableStateFlow(ServerState.STOPPED)
     val serverState = _serverState.asStateFlow()
 
@@ -166,12 +175,19 @@ class AirPlayService : Service(), RaopCallbackHandler {
         logCallback?.invoke(msg)
     }
 
+    override fun onLog(msg: String) {
+        logCallback?.invoke(msg)
+    }
+
     inner class LocalBinder : Binder() {
         val service: AirPlayService
             get() = this@AirPlayService
     }
 
-    override fun onBind(intent: Intent?): IBinder = LocalBinder()
+    override fun onBind(intent: Intent): IBinder {
+        super.onBind(intent)
+        return LocalBinder()
+    }
 
     override fun onCreate() {
         super.onCreate()
@@ -268,12 +284,16 @@ class AirPlayService : Service(), RaopCallbackHandler {
                 )
             }
         }
+        lifecycleScope.launch {
+            prefs.audioConfigFlow()
+                .debounce(AUDIO_CONFIG_DEBOUNCE_MS)
+                .collect { audioRenderer.updateConfig(it) }
+        }
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         if (intent?.action == ACTION_START_SERVER) {
             promoteToForeground()
-            val prefs = getSharedPreferences(Prefs.NAME, Context.MODE_PRIVATE)
             val name = prefs.getString(Prefs.SERVER_NAME, Prefs.DEF_SERVER_NAME) ?: Prefs.DEF_SERVER_NAME
             startServer(name, ensureServiceStarted = false)
             if (_serverState.value != ServerState.RUNNING) stopSelf(startId)
@@ -289,7 +309,6 @@ class AirPlayService : Service(), RaopCallbackHandler {
         if (_serverState.value == ServerState.RUNNING) return
         val effectiveName = name.ifBlank { Prefs.DEF_SERVER_NAME }
 
-        val prefs = getSharedPreferences(Prefs.NAME, Context.MODE_PRIVATE)
         val pm = getSystemService(Context.POWER_SERVICE) as PowerManager
         wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "airplay:server").apply { acquire() }
 
@@ -300,12 +319,22 @@ class AirPlayService : Service(), RaopCallbackHandler {
         val nohold = prefs.getBoolean(Prefs.ALLOW_NEW_CONN, Prefs.DEF_ALLOW_NEW_CONN)
         val requirePin = prefs.getBoolean(Prefs.REQUIRE_PIN, Prefs.DEF_REQUIRE_PIN)
 
+        // oboe's OpenSL ES backend (pre-AAudio devices, API < 27) can't discover native
+        // rate / burst size itself; feed it AudioManager values so low-latency buffer
+        // sizing works there
+        // see: https://github.com/google/oboe/blob/main/docs/GettingStarted.md#obtaining-optimal-latency
+        val am = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        NativeBridge.nativeSetDefaultStreamValues(
+            am.getProperty(AudioManager.PROPERTY_OUTPUT_SAMPLE_RATE)?.toIntOrNull() ?: 0,
+            am.getProperty(AudioManager.PROPERTY_OUTPUT_FRAMES_PER_BUFFER)?.toIntOrNull() ?: 0
+        )
         nativeHandle = NativeBridge.nativeInit(this, hwAddr, effectiveName, keyFile, nohold, requirePin)
         if (nativeHandle == 0L) {
             log("Native init failed")
             _failStart()
             return
         }
+        audioRenderer.attachEngine(nativeHandle)
 
         // apply settings from preferences
         val maxFps = prefs.getInt(Prefs.MAX_FPS, Prefs.DEF_MAX_FPS)
@@ -315,17 +344,16 @@ class AirPlayService : Service(), RaopCallbackHandler {
         val alac = prefs.getBoolean(Prefs.ALAC_ENABLED, Prefs.DEF_ALAC_ENABLED)
         val aac = prefs.getBoolean(Prefs.AAC_ENABLED, Prefs.DEF_AAC_ENABLED)
 
-        audioRenderer.swAlacEnabled = prefs.getBoolean(Prefs.SW_ALAC_ENABLED, Prefs.DEF_SW_ALAC_ENABLED)
-        audioRenderer.audioBufferMultiplier = prefs.getInt(Prefs.AUDIO_BUFFER_MULTIPLIER, Prefs.DEF_AUDIO_BUFFER_MULTIPLIER)
+        val realtimePriority = prefs.getBoolean(Prefs.KEY_PRIORITY, Prefs.DEF_KEY_PRIORITY)
+        val lowLatency = prefs.getBoolean(Prefs.LOW_LATENCY, Prefs.DEF_LOW_LATENCY)
         videoRenderer.enforceSdr = prefs.getBoolean(Prefs.ENFORCE_SDR, Prefs.DEF_ENFORCE_SDR)
         videoRenderer.keyAllowFrameDrop = prefs.getBoolean(Prefs.KEY_ALLOW_FRAME_DROP, Prefs.DEF_KEY_ALLOW_FRAME_DROP)
-        val realtimePriority = prefs.getBoolean(Prefs.KEY_PRIORITY, Prefs.DEF_KEY_PRIORITY)
         videoRenderer.realtimeDecoderPriority = realtimePriority
+        videoRenderer.lowLatency = lowLatency
         videoRenderer.operatingRateHint = prefs.getBoolean(Prefs.KEY_OPERATING_RATE, Prefs.DEF_KEY_OPERATING_RATE)
         videoRenderer.benchmarkLog = prefs.getBoolean(Prefs.BENCHMARK_LOG, Prefs.DEF_BENCHMARK_LOG)
         videoRenderer.benchmarkLogCallback = { msg -> logCallback?.invoke(msg) }
         videoRenderer.scheduledOutputBufferRelease = prefs.getBoolean(Prefs.SCHEDULED_OUTPUT_BUFFER_RELEASE, Prefs.DEF_SCHEDULED_OUTPUT_BUFFER_RELEASE)
-        audioRenderer.realtimeDecoderPriority = realtimePriority
         NativeBridge.nativeSetH265Enabled(nativeHandle, h265)
         NativeBridge.nativeSetCodecs(nativeHandle, alac, aac)
         val advertiseVideo = prefs.getBoolean(Prefs.ADVERTISE_VIDEO, Prefs.DEF_ADVERTISE_VIDEO)
@@ -380,6 +408,7 @@ class AirPlayService : Service(), RaopCallbackHandler {
     }
 
     private fun _failStart() {
+        audioRenderer.detachEngine()
         if (nativeHandle != 0L) {
             NativeBridge.nativeDestroy(nativeHandle)
             nativeHandle = 0L
@@ -396,6 +425,7 @@ class AirPlayService : Service(), RaopCallbackHandler {
     }
 
     fun stopServer() {
+        audioRenderer.detachEngine()
         if (nativeHandle != 0L) {
             NativeBridge.nativeStop(nativeHandle)
             NativeBridge.nativeDestroy(nativeHandle)
@@ -407,7 +437,6 @@ class AirPlayService : Service(), RaopCallbackHandler {
         wakeLock?.release()
         wakeLock = null
         videoRenderer.release()
-        audioRenderer.release()
         airPlayVideoPlayer.stop()
         mediaSession?.isActive = false
         _audioOnly.value = false
@@ -505,10 +534,6 @@ class AirPlayService : Service(), RaopCallbackHandler {
         videoRenderer.feedFrame(data, ntpTimeNs, isH265)
     }
 
-    override fun onAudioData(data: ByteArray, ct: Int, ntpTimeNs: Long, seqNum: Int) {
-        audioRenderer.feedAudio(data, ct, ntpTimeNs)
-    }
-
     override fun onVideoSessionPoll() {
         _lastVideoPollAt = SystemClock.elapsedRealtime()
     }
@@ -540,6 +565,8 @@ class AirPlayService : Service(), RaopCallbackHandler {
 
     override fun onAudioFormat(ct: Int, spf: Int, usingScreen: Boolean) {
         clearPin()
+        audioRenderer.start()
+        audioRenderer.setFormat(ct, spf)
         if (!usingScreen && !_audioOnly.value) {
             // pure music streaming (not screen mirroring audio)
             onAudioOnly(true)
@@ -579,6 +606,8 @@ class AirPlayService : Service(), RaopCallbackHandler {
         if (_connectionCount.value == 0) {
             // clients may drop without POST /stop; must run before the poll-state reset
             _endVideoPlayback("AirPlay Video stopped (disconnect)")
+            // last client gone: release audio output devices to save power
+            audioRenderer.stop()
             _audioOnly.value = false
             _mirroringActive.value = false
             _lastVideoPollAt = 0
@@ -588,14 +617,12 @@ class AirPlayService : Service(), RaopCallbackHandler {
             _positionMs.value = 0
             _durationMs.value = 0
             mediaSession?.isActive = false
-            audioRenderer.markSessionEnded()
             _refreshDacpPlayer()
         }
         log("Client disconnected (${_connectionCount.value})")
     }
 
     override fun onConnectionReset(reason: Int) {
-        audioRenderer.markSessionEnded()
         log("Connection reset: $reason")
     }
 
@@ -772,6 +799,7 @@ class AirPlayService : Service(), RaopCallbackHandler {
         framePacingJitterUs = videoRenderer.framePacingJitterUs,
         audioCodec = audioRenderer.codecLabel,
         audioVolume = (audioRenderer.volume * 100).toInt(),
+        audio = audioRenderer.audioDebug(),
         connections = _connectionCount.value,
     )
 
@@ -818,12 +846,10 @@ class AirPlayService : Service(), RaopCallbackHandler {
     }
 
     private fun requiresPin(): Boolean {
-        val prefs = getSharedPreferences(Prefs.NAME, Context.MODE_PRIVATE)
         return prefs.getBoolean(Prefs.REQUIRE_PIN, Prefs.DEF_REQUIRE_PIN)
     }
 
     private fun shouldLaunchOnConnect(): Boolean {
-        val prefs = getSharedPreferences(Prefs.NAME, Context.MODE_PRIVATE)
         return prefs.getBoolean(Prefs.LAUNCH_ON_CONNECT, Prefs.DEF_LAUNCH_ON_CONNECT)
     }
 
@@ -910,5 +936,7 @@ class AirPlayService : Service(), RaopCallbackHandler {
         // shared with dpad/double-tap seeks
         const val VIDEO_SEEK_STEP_MS = 10_000L
         const val VIDEO_POLL_PENDING_TIMEOUT_MS = 3_000L
+
+        private const val AUDIO_CONFIG_DEBOUNCE_MS = 500L
     }
 }

--- a/app/src/main/kotlin/io/github/jqssun/airplay/service/AudioPrefs.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/service/AudioPrefs.kt
@@ -1,0 +1,31 @@
+package io.github.jqssun.airplay.service
+
+import android.content.SharedPreferences
+import io.github.jqssun.airplay.Prefs
+import io.github.jqssun.airplay.renderer.AudioConfig
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+
+fun readAudioConfig(p: SharedPreferences) = AudioConfig(
+    cushionMs = if (p.getBoolean(Prefs.AUDIO_AUTO_BUFFER, Prefs.DEF_AUDIO_AUTO_BUFFER)) 0
+                else p.getInt(Prefs.AUDIO_CUSHION_MS, Prefs.DEF_AUDIO_CUSHION_MS).coerceIn(1, 1000),
+    percentilePct = Prefs.ADAPTIVE_PERCENTILES[
+        p.getInt(Prefs.AUDIO_ADAPTIVE_STEP, Prefs.DEF_AUDIO_ADAPTIVE_STEP)
+            .coerceIn(0, Prefs.ADAPTIVE_PERCENTILES.size - 1)],
+    oboeBufferFrames = p.getInt(Prefs.OBOE_BUFFER_FRAMES, Prefs.DEF_OBOE_BUFFER_FRAMES).coerceIn(0, 8192),
+    forceSwAlac = p.getBoolean(Prefs.FORCE_SW_ALAC, Prefs.DEF_FORCE_SW_ALAC),
+    realtimePriority = p.getBoolean(Prefs.KEY_PRIORITY, Prefs.DEF_KEY_PRIORITY),
+    lowLatency = p.getBoolean(Prefs.LOW_LATENCY, Prefs.DEF_LOW_LATENCY),
+    benchmarkLog = p.getBoolean(Prefs.BENCHMARK_LOG, Prefs.DEF_BENCHMARK_LOG),
+)
+
+fun SharedPreferences.audioConfigFlow(): Flow<AudioConfig> = callbackFlow {
+    val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, _ ->
+        trySend(readAudioConfig(this@audioConfigFlow))
+    }
+    trySend(readAudioConfig(this@audioConfigFlow))
+    registerOnSharedPreferenceChangeListener(listener)
+    awaitClose { unregisterOnSharedPreferenceChangeListener(listener) }
+}.distinctUntilChanged()

--- a/app/src/main/kotlin/io/github/jqssun/airplay/ui/MainScreen.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/ui/MainScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import android.content.Context
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -665,7 +666,7 @@ private fun OverviewContent(
                     }
                 }
             }
-            if (debugEnabled && connections > 0 && !showAudioMode) {
+            if (debugEnabled && connections > 0) {
                 DebugOverlay(debugInfo, Modifier.align(Alignment.TopStart).padding(8.dp))
             }
             var showRes by remember { mutableStateOf(false) }
@@ -998,17 +999,43 @@ private fun DebugOverlay(info: DebugInfo, modifier: Modifier = Modifier) {
         verticalArrangement = Arrangement.spacedBy(2.dp)
     ) {
         val style = MaterialTheme.typography.labelSmall
+        val headingStyle = style.copy(fontWeight = FontWeight.Bold)
         val color = Color.White.copy(alpha = 0.9f)
-
-        if (info.videoCodec.isNotEmpty()) {
-            Text(stringResource(R.string.debug_video, info.videoCodec, info.videoRes), style = style, color = color)
-            Text(stringResource(R.string.debug_fps_bitrate, info.videoFps, info.bitrateStr), style = style, color = color)
-            Text(stringResource(R.string.debug_frames_drops, info.videoFrames, info.droppedFrames), style = style, color = color)
-            Text(stringResource(R.string.debug_jitter, info.jitterStr), style = style, color = color)
+        val headingColor = Color(0xFF80D8FF) // cyan
+        val context = LocalContext.current
+        debugOverlaySections(context, info).forEachIndexed { i, section ->
+            if (i > 0) Spacer(Modifier.height(6.dp))
+            Text(section.title.uppercase(), style = headingStyle, color = headingColor)
+            section.lines.forEach { Text(it, style = style, color = color) }
         }
-        if (info.audioCodec.isNotEmpty()) {
-            Text(stringResource(R.string.debug_audio, info.audioCodec, info.audioVolume), style = style, color = color)
-        }
-        Text(stringResource(R.string.debug_clients, info.connections), style = style, color = color)
     }
 }
+
+private data class DebugSection(val title: String, val lines: List<String>)
+
+private fun debugOverlaySections(context: Context, info: DebugInfo): List<DebugSection> = buildList {
+    buildList {
+        if (info.videoCodec.isNotEmpty()) {
+            add(context.getString(R.string.debug_video, info.videoCodec, info.videoRes))
+            add(context.getString(R.string.debug_fps_bitrate, info.videoFps, info.bitrateStr))
+            add(context.getString(R.string.debug_frames_drops, info.videoFrames, info.droppedFrames))
+            add(context.getString(R.string.debug_jitter, info.jitterStr))
+        }
+    }.takeIf { it.isNotEmpty() }?.let { add(DebugSection(context.getString(R.string.debug_section_video), it)) }
+
+    buildList {
+        if (info.audioCodec.isNotEmpty()) add(context.getString(R.string.debug_audio, info.audioCodec, info.audioVolume))
+        info.audio?.let { a ->
+            add(context.getString(R.string.debug_audio_buffer, a.backlogMs, a.tunedCushionMs))
+            add(context.getString(R.string.debug_audio_glitch, a.trims, a.drops, a.silences, a.underruns, a.xrun))
+            add(context.getString(R.string.debug_audio_decode, formatDecode(a.decodeMeanUs, a.decodeMaxUs, a.decodeHeld)))
+        }
+    }.takeIf { it.isNotEmpty() }?.let { add(DebugSection(context.getString(R.string.debug_section_audio), it)) }
+
+    add(DebugSection(context.getString(R.string.debug_section_network), listOf(context.getString(R.string.debug_clients, info.connections))))
+}
+
+// "mean/max ms held=N", or "held=N" before first latency window lands
+private fun formatDecode(meanUs: Int, maxUs: Int, held: Int): String =
+    if (meanUs == 0) "held=$held"
+    else "%.1f/%.1f ms held=%d".format(meanUs / 1000.0, maxUs / 1000.0, held)

--- a/app/src/main/kotlin/io/github/jqssun/airplay/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/ui/SettingsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import io.github.jqssun.airplay.Prefs
 import io.github.jqssun.airplay.R
 import io.github.jqssun.airplay.viewmodel.MainViewModel
 import androidx.compose.ui.res.stringResource
@@ -53,15 +54,19 @@ fun SettingsScreen(viewModel: MainViewModel) {
     val runInBackground by viewModel.runInBackground.collectAsState()
     val serverPort by viewModel.serverPort.collectAsState()
     val audioLatencyMs by viewModel.audioLatencyMs.collectAsState()
-    val swAlacEnabled by viewModel.swAlacEnabled.collectAsState()
+    val forceSwAlac by viewModel.forceSwAlac.collectAsState()
     val debugEnabled by viewModel.debugEnabled.collectAsState()
     val developerOptions by viewModel.developerOptions.collectAsState()
     val keyAllowFrameDrop by viewModel.keyAllowFrameDrop.collectAsState()
     val realtimeDecoderPriority by viewModel.realtimeDecoderPriority.collectAsState()
+    val lowLatency by viewModel.lowLatency.collectAsState()
     val operatingRateHint by viewModel.operatingRateHint.collectAsState()
     val scheduledOutputBufferRelease by viewModel.scheduledOutputBufferRelease.collectAsState()
     val benchmarkLog by viewModel.benchmarkLog.collectAsState()
-    val audioBufferMultiplier by viewModel.audioBufferMultiplier.collectAsState()
+    val audioAutoBuffer by viewModel.audioAutoBuffer.collectAsState()
+    val audioCushionMs by viewModel.audioCushionMs.collectAsState()
+    val audioAdaptiveStep by viewModel.audioAdaptiveStep.collectAsState()
+    val oboeBufferFrames by viewModel.oboeBufferFrames.collectAsState()
 
     Column(
         modifier = Modifier
@@ -227,24 +232,10 @@ fun SettingsScreen(viewModel: MainViewModel) {
         )
 
         SettingSwitch(
-            title = stringResource(R.string.setting_alac),
-            description = stringResource(R.string.setting_alac_desc),
-            checked = alacEnabled,
-            onCheckedChange = { viewModel.setAlacEnabled(it) }
-        )
-
-        SettingSwitch(
             title = stringResource(R.string.setting_sw_alac),
             description = stringResource(R.string.setting_sw_alac_desc),
-            checked = swAlacEnabled,
-            onCheckedChange = { viewModel.setSwAlacEnabled(it) }
-        )
-
-        SettingSwitch(
-            title = stringResource(R.string.setting_aac),
-            description = stringResource(R.string.setting_aac_desc),
-            checked = aacEnabled,
-            onCheckedChange = { viewModel.setAacEnabled(it) }
+            checked = forceSwAlac,
+            onCheckedChange = { viewModel.setForceSwAlac(it) }
         )
 
         SectionHeader(stringResource(R.string.section_developer))
@@ -286,6 +277,20 @@ fun SettingsScreen(viewModel: MainViewModel) {
             )
 
             SettingSwitch(
+                title = stringResource(R.string.setting_alac),
+                description = stringResource(R.string.setting_alac_desc),
+                checked = alacEnabled,
+                onCheckedChange = { viewModel.setAlacEnabled(it) }
+            )
+
+            SettingSwitch(
+                title = stringResource(R.string.setting_aac),
+                description = stringResource(R.string.setting_aac_desc),
+                checked = aacEnabled,
+                onCheckedChange = { viewModel.setAacEnabled(it) }
+            )
+
+            SettingSwitch(
                 title = stringResource(R.string.setting_key_allow_frame_drop),
                 description = stringResource(R.string.setting_key_allow_frame_drop_desc),
                 checked = keyAllowFrameDrop,
@@ -304,6 +309,13 @@ fun SettingsScreen(viewModel: MainViewModel) {
                 description = stringResource(R.string.setting_realtime_decoder_priority_desc),
                 checked = realtimeDecoderPriority,
                 onCheckedChange = { viewModel.setRealtimeDecoderPriority(it) }
+            )
+
+            SettingSwitch(
+                title = stringResource(R.string.setting_low_latency),
+                description = stringResource(R.string.setting_low_latency_desc),
+                checked = lowLatency,
+                onCheckedChange = { viewModel.setLowLatency(it) }
             )
 
             SettingSwitch(
@@ -347,29 +359,60 @@ fun SettingsScreen(viewModel: MainViewModel) {
                 )
             }
 
-            ListItem(
-                headlineContent = { Text(stringResource(R.string.setting_audio_buffer_multiplier)) },
-                supportingContent = { Text(stringResource(R.string.setting_audio_buffer_multiplier_desc)) }
+            SettingSwitch(
+                title = stringResource(R.string.setting_audio_auto_buffer),
+                description = stringResource(R.string.setting_audio_auto_buffer_desc),
+                checked = audioAutoBuffer,
+                onCheckedChange = { viewModel.setAudioAutoBuffer(it) }
             )
-            var audioBufferSliderVal by remember(audioBufferMultiplier) {
-                mutableFloatStateOf(audioBufferMultiplier.toFloat())
+
+            if (audioAutoBuffer) {
+                val maxStep = Prefs.ADAPTIVE_PERCENTILES.size - 1
+                var stepVal by remember(audioAdaptiveStep) { mutableFloatStateOf(audioAdaptiveStep.toFloat()) }
+                ListItem(
+                    headlineContent = {
+                        Column {
+                            Slider(
+                                value = stepVal,
+                                onValueChange = { stepVal = it },
+                                onValueChangeFinished = { viewModel.setAudioAdaptiveStep(stepVal.roundToInt()) },
+                                valueRange = 0f..maxStep.toFloat(),
+                                steps = maxStep - 1,
+                                modifier = Modifier.dpadFocus().dpadAdjust(
+                                    onLeft = { viewModel.setAudioAdaptiveStep((audioAdaptiveStep - 1).coerceIn(0, maxStep)) },
+                                    onRight = { viewModel.setAudioAdaptiveStep((audioAdaptiveStep + 1).coerceIn(0, maxStep)) }
+                                )
+                            )
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween
+                            ) {
+                                Text(stringResource(R.string.audio_adaptive_low_latency),
+                                    style = MaterialTheme.typography.labelSmall)
+                                Text(stringResource(R.string.audio_adaptive_stability),
+                                    style = MaterialTheme.typography.labelSmall)
+                            }
+                        }
+                    }
+                )
+            } else {
+                SettingNumberField(
+                    title = stringResource(R.string.setting_audio_cushion_ms),
+                    description = stringResource(R.string.setting_audio_cushion_ms_desc),
+                    value = audioCushionMs,
+                    range = 1..1000,
+                    onValueChange = { viewModel.setAudioCushionMs(it) }
+                )
             }
-            ListItem(
-                headlineContent = {
-                    Slider(
-                        value = audioBufferSliderVal,
-                        onValueChange = { audioBufferSliderVal = it },
-                        onValueChangeFinished = { viewModel.setAudioBufferMultiplier(audioBufferSliderVal.roundToInt()) },
-                        valueRange = 4f..8f,
-                        steps = 3,
-                        modifier = Modifier.dpadFocus().dpadAdjust(
-                            onLeft = { viewModel.setAudioBufferMultiplier((audioBufferMultiplier - 1).coerceIn(4, 8)) },
-                            onRight = { viewModel.setAudioBufferMultiplier((audioBufferMultiplier + 1).coerceIn(4, 8)) }
-                        )
-                    )
-                },
-                trailingContent = { Text(stringResource(R.string.setting_audio_buffer_multiplier_value, audioBufferSliderVal.roundToInt())) }
+
+            SettingNumberField(
+                title = stringResource(R.string.setting_oboe_buffer_frames),
+                description = stringResource(R.string.setting_oboe_buffer_frames_desc),
+                value = oboeBufferFrames,
+                range = 0..8192,
+                onValueChange = { viewModel.setOboeBufferFrames(it) }
             )
+
 
             SettingSwitch(
                 title = stringResource(R.string.setting_debug_overlay),
@@ -486,6 +529,42 @@ private fun SettingResolution(
                         )
                     }
                 }
+            }
+        }
+    )
+}
+
+@Composable
+private fun SettingNumberField(
+    title: String,
+    description: String,
+    value: Int,
+    range: IntRange,
+    onValueChange: (Int) -> Unit
+) {
+    var text by remember(value) { mutableStateOf(value.toString()) }
+    val focus = LocalFocusManager.current
+    val parsed = text.toIntOrNull()
+    val valid = parsed != null && parsed in range
+    OutlinedTextField(
+        value = text,
+        onValueChange = { text = it.filter { c -> c.isDigit() }.take(6) },
+        label = { Text(title) },
+        supportingText = { Text(description) },
+        singleLine = true,
+        isError = !valid,
+        keyboardOptions = KeyboardOptions(
+            keyboardType = KeyboardType.Number,
+            imeAction = ImeAction.Done
+        ),
+        keyboardActions = KeyboardActions(onDone = { focus.clearFocus() }),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .padding(bottom = 8.dp),
+        trailingIcon = {
+            if (valid && parsed != value) {
+                TextButton(onClick = { onValueChange(parsed!!) }) { Text(stringResource(R.string.btn_save)) }
             }
         }
     )

--- a/app/src/main/kotlin/io/github/jqssun/airplay/viewmodel/MainViewModel.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/viewmodel/MainViewModel.kt
@@ -27,6 +27,19 @@ import java.util.Date
 import java.util.Locale
 import javax.inject.Inject
 
+data class AudioDebug(
+    val backlogMs: Int,
+    val tunedCushionMs: Int,
+    val trims: Int,
+    val drops: Int,
+    val silences: Int,
+    val underruns: Int,
+    val xrun: Int,
+    val decodeMeanUs: Int,
+    val decodeMaxUs: Int,
+    val decodeHeld: Int,
+)
+
 data class DebugInfo(
     val videoCodec: String = "",
     val videoRes: String = "",
@@ -37,6 +50,7 @@ data class DebugInfo(
     val framePacingJitterUs: Long = 0,
     val audioCodec: String = "",
     val audioVolume: Int = 100,
+    val audio: AudioDebug? = null,
     val connections: Int = 0,
 ) {
     val bitrateStr: String get() {
@@ -111,6 +125,9 @@ class MainViewModel @Inject constructor(app: Application) : AndroidViewModel(app
     private val _realtimeDecoderPriority = MutableStateFlow(prefs.getBoolean(Prefs.KEY_PRIORITY, Prefs.DEF_KEY_PRIORITY))
     val realtimeDecoderPriority: StateFlow<Boolean> = _realtimeDecoderPriority.asStateFlow()
 
+    private val _lowLatency = MutableStateFlow(prefs.getBoolean(Prefs.LOW_LATENCY, Prefs.DEF_LOW_LATENCY))
+    val lowLatency: StateFlow<Boolean> = _lowLatency.asStateFlow()
+
     private val _operatingRateHint = MutableStateFlow(prefs.getBoolean(Prefs.KEY_OPERATING_RATE, Prefs.DEF_KEY_OPERATING_RATE))
     val operatingRateHint: StateFlow<Boolean> = _operatingRateHint.asStateFlow()
 
@@ -123,8 +140,8 @@ class MainViewModel @Inject constructor(app: Application) : AndroidViewModel(app
     private val _alacEnabled = MutableStateFlow(prefs.getBoolean(Prefs.ALAC_ENABLED, Prefs.DEF_ALAC_ENABLED))
     val alacEnabled: StateFlow<Boolean> = _alacEnabled.asStateFlow()
 
-    private val _swAlacEnabled = MutableStateFlow(prefs.getBoolean(Prefs.SW_ALAC_ENABLED, Prefs.DEF_SW_ALAC_ENABLED))
-    val swAlacEnabled: StateFlow<Boolean> = _swAlacEnabled.asStateFlow()
+    private val _forceSwAlac = MutableStateFlow(prefs.getBoolean(Prefs.FORCE_SW_ALAC, Prefs.DEF_FORCE_SW_ALAC))
+    val forceSwAlac: StateFlow<Boolean> = _forceSwAlac.asStateFlow()
 
     private val _aacEnabled = MutableStateFlow(prefs.getBoolean(Prefs.AAC_ENABLED, Prefs.DEF_AAC_ENABLED))
     val aacEnabled: StateFlow<Boolean> = _aacEnabled.asStateFlow()
@@ -172,8 +189,17 @@ class MainViewModel @Inject constructor(app: Application) : AndroidViewModel(app
     private val _developerOptions = MutableStateFlow(prefs.getBoolean(Prefs.DEVELOPER_OPTIONS, Prefs.DEF_DEVELOPER_OPTIONS))
     val developerOptions: StateFlow<Boolean> = _developerOptions.asStateFlow()
 
-    private val _audioBufferMultiplier = MutableStateFlow(prefs.getInt(Prefs.AUDIO_BUFFER_MULTIPLIER, Prefs.DEF_AUDIO_BUFFER_MULTIPLIER))
-    val audioBufferMultiplier: StateFlow<Int> = _audioBufferMultiplier.asStateFlow()
+    private val _audioAutoBuffer = MutableStateFlow(prefs.getBoolean(Prefs.AUDIO_AUTO_BUFFER, Prefs.DEF_AUDIO_AUTO_BUFFER))
+    val audioAutoBuffer: StateFlow<Boolean> = _audioAutoBuffer.asStateFlow()
+
+    private val _audioCushionMs = MutableStateFlow(prefs.getInt(Prefs.AUDIO_CUSHION_MS, Prefs.DEF_AUDIO_CUSHION_MS))
+    val audioCushionMs: StateFlow<Int> = _audioCushionMs.asStateFlow()
+
+    private val _audioAdaptiveStep = MutableStateFlow(prefs.getInt(Prefs.AUDIO_ADAPTIVE_STEP, Prefs.DEF_AUDIO_ADAPTIVE_STEP))
+    val audioAdaptiveStep: StateFlow<Int> = _audioAdaptiveStep.asStateFlow()
+
+    private val _oboeBufferFrames = MutableStateFlow(prefs.getInt(Prefs.OBOE_BUFFER_FRAMES, Prefs.DEF_OBOE_BUFFER_FRAMES))
+    val oboeBufferFrames: StateFlow<Int> = _oboeBufferFrames.asStateFlow()
 
     private val _debugInfo = MutableStateFlow(DebugInfo())
     val debugInfo: StateFlow<DebugInfo> = _debugInfo.asStateFlow()
@@ -343,6 +369,10 @@ class MainViewModel @Inject constructor(app: Application) : AndroidViewModel(app
         prefs.edit().putBoolean(Prefs.KEY_PRIORITY, v).apply()
         _applyByServerRestart()
     }
+    fun setLowLatency(v: Boolean) {
+        _lowLatency.value = v
+        prefs.edit().putBoolean(Prefs.LOW_LATENCY, v).apply()
+    }
     fun setOperatingRateHint(v: Boolean) {
         _operatingRateHint.value = v
         prefs.edit().putBoolean(Prefs.KEY_OPERATING_RATE, v).apply()
@@ -358,7 +388,7 @@ class MainViewModel @Inject constructor(app: Application) : AndroidViewModel(app
         prefs.edit().putBoolean(Prefs.BENCHMARK_LOG, v).apply()
         _applyByServerRestart()
     }
-    fun setSwAlacEnabled(v: Boolean) { _swAlacEnabled.value = v; prefs.edit().putBoolean(Prefs.SW_ALAC_ENABLED, v).apply(); _applyByServerRestart() }
+    fun setForceSwAlac(v: Boolean) { _forceSwAlac.value = v; prefs.edit().putBoolean(Prefs.FORCE_SW_ALAC, v).apply() }
     fun setAlacEnabled(v: Boolean) { _alacEnabled.value = v; prefs.edit().putBoolean(Prefs.ALAC_ENABLED, v).apply(); _applyByServerRestart() }
     fun setAacEnabled(v: Boolean) { _aacEnabled.value = v; prefs.edit().putBoolean(Prefs.AAC_ENABLED, v).apply(); _applyByServerRestart() }
     fun setResolution(v: String) { _resolution.value = v; prefs.edit().putString(Prefs.RESOLUTION, v).apply(); _applyByServerRestart() }
@@ -378,11 +408,24 @@ class MainViewModel @Inject constructor(app: Application) : AndroidViewModel(app
         _developerOptions.value = v
         prefs.edit().putBoolean(Prefs.DEVELOPER_OPTIONS, v).apply()
     }
-    fun setAudioBufferMultiplier(v: Int) {
-        val value = v.coerceIn(4, 8)
-        _audioBufferMultiplier.value = value
-        prefs.edit().putInt(Prefs.AUDIO_BUFFER_MULTIPLIER, value).apply()
-        _applyByServerRestart()
+    fun setAudioAutoBuffer(v: Boolean) {
+        _audioAutoBuffer.value = v
+        prefs.edit().putBoolean(Prefs.AUDIO_AUTO_BUFFER, v).apply()
+    }
+    fun setAudioCushionMs(v: Int) {
+        val value = v.coerceIn(1, 1000)
+        _audioCushionMs.value = value
+        prefs.edit().putInt(Prefs.AUDIO_CUSHION_MS, value).apply()
+    }
+    fun setAudioAdaptiveStep(v: Int) {
+        val value = v.coerceIn(0, Prefs.ADAPTIVE_PERCENTILES.size - 1)
+        _audioAdaptiveStep.value = value
+        prefs.edit().putInt(Prefs.AUDIO_ADAPTIVE_STEP, value).apply()
+    }
+    fun setOboeBufferFrames(v: Int) {
+        val value = v.coerceIn(0, 8192)
+        _oboeBufferFrames.value = value
+        prefs.edit().putInt(Prefs.OBOE_BUFFER_FRAMES, value).apply()
     }
 
     // service binding

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,6 +107,10 @@
     <string name="setting_advertise_video_desc">When off, videos are cast as audio only streams</string>
     <string name="setting_advertise_audio">Advertise AirPlay audio support</string>
     <string name="setting_advertise_audio_desc">When off, the device can only be used for mirroring and will be hidden from media players</string>
+    <string name="setting_alac">Advertise ALAC codec</string>
+    <string name="setting_alac_desc">Offer ALAC in the mDNS record; used for AirPlay music streaming</string>
+    <string name="setting_aac">Advertise AAC codec</string>
+    <string name="setting_aac_desc">Offer AAC-ELD/AAC-LC in the mDNS record; used for screen mirroring audio</string>
     <string name="setting_launch_on_connect">Open this application on connect</string>
     <string name="setting_launch_on_connect_desc">Show the screen when a client connects</string>
     <string name="setting_launch_on_connect_no_permission">Tap to grant Display over other apps permission</string>
@@ -128,12 +132,8 @@
     <string name="setting_h265_desc">Enable H.265 video decoding if device supports it</string>
     <string name="setting_enforce_sdr">MediaFormat.KEY_COLOR_TRANSFER</string>
     <string name="setting_enforce_sdr_desc">Tag video as limited SDR; disable to allow HDR sources to pass through</string>
-    <string name="setting_alac">ALAC audio</string>
-    <string name="setting_alac_desc">ALAC codec for AirPlay music streaming</string>
-    <string name="setting_sw_alac">Software ALAC decoder</string>
-    <string name="setting_sw_alac_desc">Use built-in decoder if platform ALAC is unavailable</string>
-    <string name="setting_aac">AAC audio</string>
-    <string name="setting_aac_desc">AAC-ELD or AAC-LC codec for screen mirroring audio</string>
+    <string name="setting_sw_alac">Force software ALAC decoder</string>
+    <string name="setting_sw_alac_desc">Always use software ALAC decoder regardless of hardware decoder availability, may affect audio latency</string>
 
     <!-- Settings: Developer -->
     <string name="setting_developer_options">Developer options</string>
@@ -142,6 +142,8 @@
     <string name="setting_key_allow_frame_drop_desc">Allow video decoders to drop frames internally to keep up on Android 10+</string>
     <string name="setting_realtime_decoder_priority">MediaFormat.KEY_PRIORITY</string>
     <string name="setting_realtime_decoder_priority_desc">Request real-time scheduling for audio and video decoders</string>
+    <string name="setting_low_latency">Low latency</string>
+    <string name="setting_low_latency_desc">Use low-latency audio and video decoding for output. Uses more power and CPU.</string>
     <string name="setting_operating_rate_hint">MediaFormat.KEY_OPERATING_RATE</string>
     <string name="setting_operating_rate_hint_desc">Request maximum operating rate for video decoder</string>
     <string name="setting_scheduled_output_buffer_release">Aligned frame pacing</string>
@@ -149,19 +151,30 @@
     <string name="setting_audio_delay">Override audio delay</string>
     <string name="setting_audio_delay_desc">Set a custom audio latency reported to client</string>
     <string name="audio_delay_value">%dms</string>
-    <string name="setting_audio_buffer_multiplier">Audio buffer size</string>
-    <string name="setting_audio_buffer_multiplier_desc">AudioTrack buffer size multiplier</string>
-    <string name="setting_audio_buffer_multiplier_value">%dx</string>
+    <string name="setting_audio_auto_buffer">Automatic audio buffer size</string>
+    <string name="setting_audio_auto_buffer_desc">Automatically tune the audio buffer according to network conditions and device performance</string>
+    <string name="audio_adaptive_low_latency">Prioritize low latency</string>
+    <string name="audio_adaptive_stability">Prioritize stability</string>
+    <string name="setting_audio_cushion_ms">Audio buffer (ms)</string>
+    <string name="setting_audio_cushion_ms_desc">Buffer to absorb network and audio decode jitter. Shorter duration means lower latency, longer duration means fewer glitches.</string>
+    <string name="setting_oboe_buffer_frames">Hardware audio buffer size (frames)</string>
+    <string name="setting_oboe_buffer_frames_desc">Keep this at 0 for automatic tuning</string>
     <string name="setting_debug_overlay">Show debug overlay</string>
     <string name="setting_debug_overlay_desc">Overlay stream stats on video: codec, FPS, bitrate, jitter, frames, drops</string>
     <string name="setting_benchmark_log">Enable debug logging</string>
     <string name="setting_benchmark_log_desc">Log stream stats to logcat: codec, FPS, bitrate, jitter, frames, drops</string>
 
     <!-- Debug overlay -->
-    <string name="debug_video">Video: %1$s %2$s</string>
+    <string name="debug_section_video">Video</string>
+    <string name="debug_section_audio">Audio</string>
+    <string name="debug_section_network">Network</string>
+    <string name="debug_video">%1$s %2$s</string>
     <string name="debug_fps_bitrate">FPS: %1$d  Bitrate: %2$s</string>
     <string name="debug_frames_drops">Frames: %1$d  Drops: %2$d</string>
     <string name="debug_jitter">Jitter: %1$s</string>
-    <string name="debug_audio">Audio: %1$s  Vol: %2$d%%</string>
+    <string name="debug_audio">%1$s  Vol: %2$d%%</string>
+    <string name="debug_audio_buffer">Buffer: %1$d ms (tgt: %2$d ms)</string>
+    <string name="debug_audio_glitch">Glitch: trim=%1$d drop=%2$d sil=%3$d ur=%4$d xrun=%5$d</string>
+    <string name="debug_audio_decode">Decode: %1$s</string>
     <string name="debug_clients">Clients: %1$d</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,11 +11,13 @@ core-ktx = "1.15.0"
 datastore = "1.1.1"
 coroutines = "1.9.0"
 media3 = "1.11.0-beta01"
+oboe = "1.9.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
 androidx-lifecycle-runtime = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }
+androidx-lifecycle-service = { group = "androidx.lifecycle", name = "lifecycle-service", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 androidx-datastore-prefs = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 
@@ -38,6 +40,8 @@ media3-transformer = { group = "androidx.media3", name = "media3-transformer", v
 media3-ui-compose-material3 = { group = "androidx.media3", name = "media3-ui-compose-material3", version.ref = "media3" }
 
 kotlinx-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
+
+oboe = { group = "com.google.oboe", name = "oboe", version.ref = "oboe" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This PR replaces the existing Java-based audio pipeline with a low-latency pipeline written entirely in C++. With these changes, most light mobile games are playable over Airplay.

The new pipeline consists of 3 components:

### Decoder

#### *MediaCodecDecoder*

Similar to the existing MediaCodec-based decoder, except we call it from C++ via AMediaCodec.

Some small tweaks have been made though:

- Instead of queuing input + popping decoded output on the same thread, we use two separate threads. This nets a small (<10ms) latency reduction.
- The default Android software AAC decoder runs in a sandbox, passing data across the sandbox boundary incurs a latency penalty (~10ms). Instead, we explicitly request an in-process AAC decoder if available, before falling back to hardware AAC or sandboxed AAC decoding.
  - Maybe we should do "HW AAC > in-process SW AAC > sandboxed SW AAC" instead? I don't have a HW AAC device so I'm not able to test if HW AAC should be prioritized
 - We request low-latency decoding on both the audio decoder and the video decoder.

#### *SoftwareAlacDecoder*

Basically just the existing embedded Apple software ALAC decoder, left mostly unchanged.

### Buffering

`TimelineBuffer` is a lock-free ring buffer responsible for responsible for absorbing network/decoder latency spikes and performing PTS synchronization (the old audio renderer seems to ignore PTS).

The buffer's size is automatically tuned via the following algorithm, inspired by [NetEQ](https://webrtchacks.com/how-webrtcs-neteq-jitter-buffer-provides-smooth-audio/):
1. Estimate network/decoder latency and jitter from the packet arrival time and pts.
2. Graph the jitter on a decaying histogram. The histogram let's us answer this question: "What is the minimum amount of jitter we need to absorb to accommodate 95% of packets?" Decaying the histogram over time allows it to forget old data points so very old jitter spikes do not factor into recent calculations. The 95% target percentile can be customized by the user.
3. We need to have enough room in the buffer to tide us over until the next audio packet arrives. This is usually around 10-20ms.
4. If the hardware reads large chunks of data at a time, we need to have enough room in the buffer to satisfy at least one read. E.g. When in power-saving mode, the hardware can read >80ms of audio data in one go. If this read happens when we have <80ms of audio data in the buffer, the buffer will instantly underrun.
5. So the final buffer size is calculated as:
    $P_{95}\text{jitter} + \text{max(audio packet size, HW buffer size)}$

The buffer automatically skips audio if too much audio remains buffered for some time. PTS sync is done by inserting silence.

### Output

Google's [oboe](https://github.com/google/oboe) audio library is used for low-latency audio output. Nothing really complicated here, we just follow all of Google's recommendations here: https://developer.android.com/games/sdk/oboe/low-latency-audio We don't request `EXCLUSIVE` mode though, I think it's overkill.

## Misc changes
- The debug overlay is now split into sections for audio, video & network.
- The audio engine automatically reloads when it's settings are changed.

## Misc notes

- ~~I haven't had the chance to do measurements yet:~~
  - On my network, the new impl delivers:
    - ~50ms latency during AAC screen mirroring
    - ~70ms latency during ALAC audio-only casting
  - It is a bit difficult to test the old impl since sounds that are too short don't play and get buffered until the buffer is large enough to play. But I measured roughly 200ms latency in screen mirroring mode. Audio-only casting doesn't seem to work for me on the old impl.
- ~~I have not tested on low-end devices yet, I plan to do so shortly.~~ Low-latency mode seems to work fine on my chromecast, latency is about the same as on my flagship phone. 
- Oboe supports [offload playback mode](https://github.com/google/oboe/wiki/Using-Offload-Playback-for-Power%E2%80%90Saving) for ultra-low power playback. I don't have any devices to test this with and I'm not really sure if it's worth the effort to implement it. Maybe I can implement it if the current implementation is too heavy on low-end devices.
- The majority of the audio engine is hand-written, though AI was used to wire up preferences, debug UI changes and make targeted edits.