### PR TITLE
fix(discovery): use unique per-install device MAC

### DIFF
--- a/app/src/main/kotlin/io/github/jqssun/airplay/Prefs.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/Prefs.kt
@@ -7,6 +7,7 @@ object Prefs {
     const val NAME = "settings"
 
     const val SERVER_NAME = "server_name"; const val DEF_SERVER_NAME = "Android AirPlay"
+    const val FALLBACK_MAC_ADDRESS = "fallback_mac_address"
     const val SERVER_PORT = "server_port"; const val DEF_SERVER_PORT = 7000
     const val AUTO_START = "auto_start"; const val DEF_AUTO_START = true
     const val BOOT_AUTO_START = "boot_auto_start"; const val DEF_BOOT_AUTO_START = true

--- a/app/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
@@ -47,6 +47,7 @@ import io.github.jqssun.airplay.renderer.AudioRenderer
 import io.github.jqssun.airplay.renderer.VideoRenderer
 import io.github.jqssun.airplay.viewmodel.DebugInfo
 import java.net.NetworkInterface
+import java.security.SecureRandom
 import kotlin.math.abs
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -811,14 +812,50 @@ class AirPlayService : LifecycleService(), RaopCallbackHandler, LogListener {
             for (iface in interfaces) {
                 if (iface.name.startsWith("wlan") || iface.name.startsWith("eth")) {
                     val mac = iface.hardwareAddress
-                    if (mac != null && mac.size == 6) return mac
+                    if (isUsableMac(mac)) return mac!!
                 }
             }
         } catch (e: Exception) {
             Log.w(TAG, "Failed to get hardware address", e)
         }
-        // fallback: random-ish address
-        return byteArrayOf(0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte(), 0xDD.toByte(), 0xEE.toByte(), 0xFF.toByte())
+
+        // fall back to stable per-install random address
+        return persistedRandomMac()
+            ?: byteArrayOf(0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte(), 0xDD.toByte(), 0xEE.toByte(), 0xFF.toByte())
+    }
+
+    private fun isUsableMac(mac: ByteArray?): Boolean =
+        mac != null && mac.size == 6 &&
+            mac.any { it != 0.toByte() } &&
+            !(mac[0] == 0x02.toByte() && mac.drop(1).all { it == 0.toByte() })
+
+    private fun persistedRandomMac(): ByteArray? {
+        macFromString(prefs.getString(Prefs.FALLBACK_MAC_ADDRESS, null))
+            ?.takeIf { isUsableMac(it) }?.let { return it }
+        repeat(10) {
+            val mac = randomAaiMac()
+            if (isUsableMac(mac)) {
+                prefs.edit().putString(Prefs.FALLBACK_MAC_ADDRESS, macToString(mac)).apply()
+                return mac
+            }
+        }
+        return null
+    }
+
+    // random locally-administered unicast MAC in AAI SLAP quadrant
+    private fun randomAaiMac(): ByteArray {
+        val mac = ByteArray(6).also { SecureRandom().nextBytes(it) }
+        mac[0] = ((mac[0].toInt() and 0xF0) or 0x0A).toByte()
+        return mac
+    }
+
+    private fun macToString(mac: ByteArray): String = mac.joinToString(":") { "%02x".format(it) }
+
+    private fun macFromString(s: String?): ByteArray? {
+        if (s == null) return null
+        return try {
+            s.split(":").map { it.toInt(16).toByte() }.toByteArray()
+        } catch (e: Exception) { null }
     }
 
     private fun createNotificationChannel() {


### PR DESCRIPTION
If you run multiple instances of this app (on different phones) on the same network, clients will treat all the instances as one instance because they all broadcast the same deviceId (MAC address).

E.g.:

1. I start android-airplay-server on "phone A"
2. I start android-airplay-server on "phone B"
3. On my iPhone I only see the "phone B" receiver, or I only see the "phone A" receiver. The other receiver is ignored and I can't cast to it.

This PR fixes this by making each device generate, save & broadcast a random deviceId.