### PR TITLE
fix decoder crashes on ultra-tall screens, add Auto Resolution

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
         applicationId = "io.github.jqssun.airplay"
         minSdk = 24
         targetSdk = 35
-        versionCode = 24
-        versionName = "0.0.24"
+        versionCode = 25
+        versionName = "0.0.25"
 
         ndk {
             abiFilters += listOf("arm64-v8a", "armeabi-v7a", "x86_64")

--- a/app/src/main/kotlin/io/github/jqssun/airplay/renderer/VideoRenderer.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/renderer/VideoRenderer.kt
@@ -186,9 +186,12 @@ class VideoRenderer {
             _startDecoder(MediaCodec.createDecoderByType(mime), format, s, h265)
         } catch (e: Exception) {
             // strict hw decoders reject configs beyond their real limits
+            val sw = _softwareDecoder(mime)?.takeIf {
+                it.getCapabilitiesForType(mime).videoCapabilities
+                    ?.isSizeSupported(videoWidth, videoHeight) == true
+            } ?: throw e
             Log.w(TAG, "Hardware decoder failed, trying software fallback", e)
-            val name = _softwareDecoderName(mime) ?: throw e
-            _startDecoder(MediaCodec.createByCodecName(name), format, s, h265)
+            _startDecoder(MediaCodec.createByCodecName(sw.name), format, s, h265)
         }
         Log.i(TAG, "Video codec started: $mime ${videoWidth}x${videoHeight} ($codecName)")
     }
@@ -292,22 +295,32 @@ class VideoRenderer {
             }
         }
 
-        // limits of the decoder createDecoderByType would pick
+        // smallest limits across codecs the sender may pick; unknown limits assume 1080p, which any device decodes
         fun maxSupportedResolution(h265: Boolean): Pair<Int, Int> {
-            val mime = if (h265) MediaFormat.MIMETYPE_VIDEO_HEVC else MediaFormat.MIMETYPE_VIDEO_AVC
-            try {
-                val caps = MediaCodecList(MediaCodecList.REGULAR_CODECS).codecInfos
-                    .firstOrNull { info ->
-                        !info.isEncoder && info.supportedTypes.any { it.equals(mime, ignoreCase = true) }
-                    }?.getCapabilitiesForType(mime)?.videoCapabilities
-                if (caps != null) return caps.supportedWidths.upper to caps.supportedHeights.upper
-            } catch (e: Exception) {
-                Log.w(TAG, "Failed to get decoder capabilities", e)
-            }
-            return 1920 to 1080
+            val mimes = listOfNotNull(
+                MediaFormat.MIMETYPE_VIDEO_AVC,
+                MediaFormat.MIMETYPE_VIDEO_HEVC.takeIf { h265 },
+            )
+            return mimes
+                .map { mime ->
+                    _decoderCaps(mime)?.let { it.supportedWidths.upper to it.supportedHeights.upper }
+                        ?: (1920 to 1080)
+                }
+                .reduce { (w1, h1), (w2, h2) -> minOf(w1, w2) to minOf(h1, h2) }
         }
 
-        private fun _softwareDecoderName(mime: String): String? =
+        // caps of the decoder createDecoderByType would pick
+        private fun _decoderCaps(mime: String) = try {
+            MediaCodecList(MediaCodecList.REGULAR_CODECS).codecInfos
+                .firstOrNull { info ->
+                    !info.isEncoder && info.supportedTypes.any { it.equals(mime, ignoreCase = true) }
+                }?.getCapabilitiesForType(mime)?.videoCapabilities
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to get decoder capabilities", e)
+            null
+        }
+
+        private fun _softwareDecoder(mime: String) =
             MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos.firstOrNull { info ->
                 !info.isEncoder && info.supportedTypes.any { it.equals(mime, ignoreCase = true) } &&
                     (if (android.os.Build.VERSION.SDK_INT >= 29) info.isSoftwareOnly
@@ -315,6 +328,6 @@ class VideoRenderer {
                         it.startsWith("omx.google.") || it.startsWith("c2.android.") ||
                             (!it.startsWith("omx.") && !it.startsWith("c2."))
                     })
-            }?.name
+            }
     }
 }

--- a/app/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
@@ -342,7 +342,7 @@ class AirPlayService : LifecycleService(), RaopCallbackHandler, LogListener {
         val maxFps = prefs.getInt(Prefs.MAX_FPS, Prefs.DEF_MAX_FPS)
         val overscanned = prefs.getBoolean(Prefs.OVERSCANNED, Prefs.DEF_OVERSCANNED)
         val audioLatencyMs = prefs.getInt(Prefs.AUDIO_LATENCY_MS, Prefs.DEF_AUDIO_LATENCY_MS)
-        val h265 = prefs.getBoolean(Prefs.H265_ENABLED, Prefs.DEF_H265_ENABLED)
+        val h265 = prefs.getBoolean(Prefs.H265_ENABLED, Prefs.DEF_H265_ENABLED) && VideoRenderer.supportsH265()
         val alac = prefs.getBoolean(Prefs.ALAC_ENABLED, Prefs.DEF_ALAC_ENABLED)
         val aac = prefs.getBoolean(Prefs.AAC_ENABLED, Prefs.DEF_AAC_ENABLED)
 


### PR DESCRIPTION
I knocked out a few major usability bugs, around hardware decoding limits, and handling screen resolutions better.



- No More Black Screens on Older Chips (Fixes #30): Devices with strict decoder limits (like the Adreno 610) were crashing and showing black screens when trying to handle modern, tall phone screens. The app now checks the hardware limits first and automatically scales the video down to a safe size without messing up the aspect ratio. If hardware decoding still fails, it automatically falls back to software decoding as a safety net

- New "Auto Resolution" Toggle: I added a new switch in the Settings. When turned on, it forces the stream to match the device's exact, native screen resolution. helpful if you want to view high-res photos in pixel-perfect quality instead of having them squished down to 1080p.

- Fixed Boot-up Black Screens on Legacy TVs (Fixes #7): Older, slower TV chips (like the Mali-470) were choking on the very first frame of the video stream. I gave the decoder a little more time (up to one second) to digest that first frame, which completely fixes the permanent black screen issue on these TVs

- "Added" ATV Support: app previously required a touchscreen by default, which kept it hidden from Android TVs. I updated the manifest so a touchscreen is no longer required, making it fully visible and compatible with standard TV remotes. Tested, confirmed working on my AndroidTV

- Better Debugging Details: The on-screen debug overlay now shows the actual, specific decoder name being used (e.g., OMX.qcom.video.decoder.avc) instead of a generic label like H.264. This will make it much easier to troubleshoot device-specific issues in the future.