### PR TITLE
feat(build): add sanitize build variant (HWASan + UBSan)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,6 +12,8 @@ val localProps = Properties().apply {
     rootProject.file("local.properties").takeIf { it.exists() }?.inputStream()?.use(::load)
 }
 
+val allAbis = listOf("arm64-v8a", "armeabi-v7a", "x86_64")
+
 android {
     namespace = "io.github.jqssun.airplay"
     compileSdk = 36
@@ -32,12 +34,8 @@ android {
         applicationId = "io.github.jqssun.airplay"
         minSdk = 24
         targetSdk = 35
-        versionCode = 27
-        versionName = "0.0.27"
-
-        ndk {
-            abiFilters += listOf("arm64-v8a", "armeabi-v7a", "x86_64")
-        }
+        versionCode = 28
+        versionName = "0.0.28"
 
         externalNativeBuild {
             cmake {
@@ -54,10 +52,26 @@ android {
     }
 
     buildTypes {
+        debug {
+            ndk { abiFilters += allAbis }
+        }
         release {
             isMinifyEnabled = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
             signingConfigs.findByName("release")?.let { signingConfig = it }
+            ndk { abiFilters += allAbis }
+        }
+        // debuggable build with HWASan (arm64) + UBSan in native code
+        create("sanitize") {
+            initWith(getByName("debug"))
+            matchingFallbacks += "debug"
+            ndk {
+                abiFilters.clear()
+                abiFilters += "arm64-v8a"
+            }
+            externalNativeBuild {
+                cmake { arguments += "-DSANITIZE=ON" }
+            }
         }
     }
 

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -20,6 +20,20 @@ set(FORWARD_ANDROID_NDK_ROOT "${ANDROID_NDK}" CACHE STRING "" FORCE) # CI
 list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 add_subdirectory(third_party/openssl-cmake)
 
+# ---------- Sanitizers (opt-in via -DSANITIZE=ON) ----------
+# OpenSSL uninstrumented; HWASan is arm64-only
+option(SANITIZE "Enable UBSan (and HWASan on arm64) for the native code" OFF)
+if(SANITIZE)
+    set(SANITIZE_CFLAGS -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize=vptr)
+    set(SANITIZE_LDFLAGS -fsanitize=undefined)
+    if(ANDROID_ABI STREQUAL "arm64-v8a")
+        list(APPEND SANITIZE_CFLAGS -fsanitize=hwaddress)
+        list(APPEND SANITIZE_LDFLAGS -fsanitize=hwaddress)
+    endif()
+    add_compile_options(${SANITIZE_CFLAGS})
+    add_link_options(${SANITIZE_LDFLAGS})
+endif()
+
 # ---------- Oboe (low-latency audio output, via prefab AAR) ----------
 find_package(oboe REQUIRED CONFIG)
 

--- a/app/src/main/cpp/cmake/BuildFFmpeg.cmake
+++ b/app/src/main/cpp/cmake/BuildFFmpeg.cmake
@@ -30,6 +30,14 @@ endif()
 
 set(FFMPEG_INSTALL ${CMAKE_BINARY_DIR}/ffmpeg)
 
+# instrument ffmpeg with the same sanitizers; built with --disable-asm
+set(_ffmpeg_sanitize "")
+if(SANITIZE)
+    string(REPLACE ";" " " _ff_scflags "${SANITIZE_CFLAGS}")
+    string(REPLACE ";" " " _ff_sldflags "${SANITIZE_LDFLAGS}")
+    set(_ffmpeg_sanitize "--extra-cflags=${_ff_scflags}" "--extra-ldflags=${_ff_sldflags}")
+endif()
+
 ExternalProject_Add(ffmpeg_ep
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/ffmpeg
     DOWNLOAD_COMMAND ""
@@ -46,6 +54,7 @@ ExternalProject_Add(ffmpeg_ep
         --enable-pic --disable-asm --disable-x86asm
         --disable-all --disable-debug --disable-network --disable-autodetect
         --enable-avcodec --enable-decoder=alac --enable-static --disable-shared
+        ${_ffmpeg_sanitize}
     BUILD_COMMAND make -j${_ffmpeg_jobs}
     INSTALL_COMMAND make install
     BUILD_BYPRODUCTS ${FFMPEG_INSTALL}/lib/libavcodec.a ${FFMPEG_INSTALL}/lib/libavutil.a

--- a/app/src/main/kotlin/io/github/jqssun/airplay/ui/Tv.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/ui/Tv.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
+import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
@@ -22,6 +23,7 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.shape.RoundedCornerShape
 
@@ -42,12 +44,17 @@ fun Modifier.dpadFocus(shape: Shape = RoundedCornerShape(12.dp)): Modifier = com
         .border(2.dp, if (focused) MaterialTheme.colorScheme.primary else Color.Transparent, shape)
 }
 
-fun Modifier.dpadAdjust(onLeft: () -> Unit, onRight: () -> Unit): Modifier =
+fun Modifier.dpadAdjust(onLeft: () -> Unit, onRight: () -> Unit): Modifier = composed {
+    val focus = LocalFocusManager.current
     onPreviewKeyEvent { e ->
         if (e.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
         when (e.key) {
             Key.DirectionLeft -> { onLeft(); true }
             Key.DirectionRight -> { onRight(); true }
+            // slider
+            Key.DirectionUp -> { focus.moveFocus(FocusDirection.Up); true }
+            Key.DirectionDown -> { focus.moveFocus(FocusDirection.Down); true }
             else -> false
         }
     }
+}

--- a/app/src/sanitize/resources/lib/arm64-v8a/wrap.sh
+++ b/app/src/sanitize/resources/lib/arm64-v8a/wrap.sh
@@ -1,0 +1,3 @@
+#!/system/bin/sh
+# https://developer.android.com/ndk/guides/hwasan#wrapsh
+LD_HWASAN=1 exec "$@"


### PR DESCRIPTION
Thought it might be useful to have a build type that enables the [HWASan](https://developer.android.com/ndk/guides/hwasan) and [UBSan](https://source.android.com/docs/security/test/ubsan) sanitizers, given the increasing amount of native code in the app. Use `./gradlew :app:assembleSanitize` to build an APK that has the sanitizers enabled.

Enabling the new sanitizers didn't reveal any issues with the app's own native code, but UBSan did report some issues inside UxPlay:

<details>

<summary>Show report content:</summary>

```
/home/nulldev/Desktop/android-airplay-server/app/src/main/cpp/third_party/UxPlay/lib/playfair/modified_md5.c:77:28: runtime error: left shift of 250 by 24 places cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/nulldev/Desktop/android-airplay-server/app/src/main/cpp/third_party/UxPlay/lib/playfair/modified_md5.c:77:28 
/home/nulldev/Desktop/android-airplay-server/app/src/main/cpp/third_party/UxPlay/lib/playfair/hand_garble.c:266:101: runtime error: signed integer overflow: 11089567 * 223 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/nulldev/Desktop/android-airplay-server/app/src/main/cpp/third_party/UxPlay/lib/playfair/hand_garble.c:266:101 
/home/nulldev/Desktop/android-airplay-server/app/src/main/cpp/third_party/UxPlay/lib/byteutils.c:55:12: runtime error: load of misaligned address 0xcb00004d1a734e95 for type 'uint16_t' (aka 'unsigned short'), which requires 2 byte alignment
0xcb00004d1a734e95: note: pointer points here
 90 a1 00 01 00 40 42  01 01 01 60 00 00 03 00  b0 00 00 03 00 00 03 00  96 a0 02 20 80 09 31 cb  11
             ^ 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/nulldev/Desktop/android-airplay-server/app/src/main/cpp/third_party/UxPlay/lib/byteutils.c:55:12 
/home/nulldev/Desktop/android-airplay-server/app/src/main/cpp/third_party/UxPlay/lib/byteutils.c:62:12: runtime error: load of misaligned address 0xb500005e1a76106b for type 'uint32_t' (aka 'unsigned int'), which requires 4 byte alignment
0xb500005e1a76106b: note: pointer points here
 72  f0 5b 24 00 00 26 d2 28  01 af 15 60 4a 16 06 c0  a8 14 02 a0 a0 26 84 d0  84 0f c1 b8 3e 08 20
              ^ 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/nulldev/Desktop/android-airplay-server/app/src/main/cpp/third_party/UxPlay/lib/byteutils.c:62:12 
```

</details>

The issues in the report don't look that serious, so I'm not going to bother fixing them for now.