### PR TITLE
feat: mirror orientation sync & stream stats display

### DIFF
--- a/app/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
@@ -10,6 +10,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.SharedPreferences
 import android.content.pm.ServiceInfo
+import android.content.res.Configuration
 import android.graphics.BitmapFactory
 import android.media.AudioManager
 import android.os.Binder
@@ -70,6 +71,7 @@ class AirPlayService : LifecycleService(), RaopCallbackHandler, LogListener {
     private var nsdManager: NsdServiceManager? = null
     private var wakeLock: PowerManager.WakeLock? = null
     private var foregroundStarted = false
+    private var lastOrientation = Configuration.ORIENTATION_UNDEFINED
 
     val videoRenderer = VideoRenderer()
     val audioRenderer = AudioRenderer()
@@ -342,7 +344,7 @@ class AirPlayService : LifecycleService(), RaopCallbackHandler, LogListener {
         val maxFps = prefs.getInt(Prefs.MAX_FPS, Prefs.DEF_MAX_FPS)
         val overscanned = prefs.getBoolean(Prefs.OVERSCANNED, Prefs.DEF_OVERSCANNED)
         val audioLatencyMs = prefs.getInt(Prefs.AUDIO_LATENCY_MS, Prefs.DEF_AUDIO_LATENCY_MS)
-        val h265 = prefs.getBoolean(Prefs.H265_ENABLED, Prefs.DEF_H265_ENABLED) && VideoRenderer.supportsH265()
+        val h265 = _h265()
         val alac = prefs.getBoolean(Prefs.ALAC_ENABLED, Prefs.DEF_ALAC_ENABLED)
         val aac = prefs.getBoolean(Prefs.AAC_ENABLED, Prefs.DEF_AAC_ENABLED)
 
@@ -369,16 +371,8 @@ class AirPlayService : LifecycleService(), RaopCallbackHandler, LogListener {
         }
 
         // set display params
-        val res = prefs.getString(Prefs.RESOLUTION, Prefs.DEF_RESOLUTION)!!
-        val (rawW, rawH) = when {
-            prefs.getBoolean(Prefs.AUTO_RES, Prefs.DEF_AUTO_RES) -> realDisplaySize()
-            res != "auto" && res.contains("x") -> res.split("x").let { it[0].toInt() to it[1].toInt() }
-            else -> resources.displayMetrics.let { it.widthPixels to it.heightPixels }
-        }
-        // strict decoders black-screen past their limits; advertised size is only upper bound for senders
-        val (maxW, maxH) = VideoRenderer.maxSupportedResolution(h265)
-        val w = rawW.coerceAtMost(maxW)
-        val h = rawH.coerceAtMost(maxH)
+        lastOrientation = resources.configuration.orientation
+        val (w, h) = _displaySize()
         videoRenderer.setResolution(w, h)
         _videoResolution.value = "${w}x${h}"
         _videoAspect.value = w.toFloat() / h
@@ -409,6 +403,44 @@ class AirPlayService : LifecycleService(), RaopCallbackHandler, LogListener {
         }
         promoteToForeground()
         log("Server started on port $port")
+    }
+
+    private fun _h265(): Boolean =
+        prefs.getBoolean(Prefs.H265_ENABLED, Prefs.DEF_H265_ENABLED) && VideoRenderer.supportsH265()
+
+    private fun _orientationFollowsDevice(): Boolean =
+        prefs.getBoolean(Prefs.AUTO_RES, Prefs.DEF_AUTO_RES) ||
+            prefs.getString(Prefs.RESOLUTION, Prefs.DEF_RESOLUTION) == "auto"
+
+    private fun _displaySize(): Pair<Int, Int> {
+        val autoRes = prefs.getBoolean(Prefs.AUTO_RES, Prefs.DEF_AUTO_RES)
+        val res = if (autoRes) "auto" else prefs.getString(Prefs.RESOLUTION, Prefs.DEF_RESOLUTION)!!
+        val (w, h) = if (res.contains("x")) {
+            res.split("x").let { it[0].toInt() to it[1].toInt() }
+        } else {
+            val (rawW, rawH) = if (autoRes) realDisplaySize()
+                else resources.displayMetrics.let { it.widthPixels to it.heightPixels }
+            val portrait = when (res) {
+                "portrait" -> true
+                "landscape" -> false
+                else -> resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT
+            }
+            if (portrait != rawH >= rawW) rawH to rawW else rawW to rawH
+        }
+        // strict decoders black-screen past their limits; advertised size is only upper bound for senders
+        val (maxW, maxH) = VideoRenderer.maxSupportedResolution(_h265())
+        return w.coerceAtMost(maxW) to h.coerceAtMost(maxH)
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        if (newConfig.orientation == lastOrientation) return
+        lastOrientation = newConfig.orientation
+        if (nativeHandle == 0L || _serverState.value != ServerState.RUNNING) return
+        if (!_orientationFollowsDevice()) return
+        val (w, h) = _displaySize()
+        NativeBridge.nativeSetDisplaySize(nativeHandle, w, h, prefs.getInt(Prefs.MAX_FPS, Prefs.DEF_MAX_FPS))
+        log("Advertising ${w}x${h} from next session")
     }
 
     private fun _failStart() {

--- a/app/src/main/kotlin/io/github/jqssun/airplay/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/ui/SettingsScreen.kt
@@ -464,6 +464,8 @@ private fun SettingResolution(
 ) {
     val presets = listOf(
         "auto" to stringResource(R.string.setting_resolution_auto),
+        "portrait" to stringResource(R.string.chip_device_portrait),
+        "landscape" to stringResource(R.string.chip_device_landscape),
         "1280x720" to "1280x720",
         "1920x1080" to "1920x1080",
         "3840x2160" to "3840x2160"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -128,6 +128,8 @@
     <string name="setting_overscanned">Overscanned</string>
     <string name="setting_overscanned_desc">Add pixel boundary for full-screen overscan displays</string>
     <string name="chip_custom">Custom</string>
+    <string name="chip_device_portrait">Portrait</string>
+    <string name="chip_device_landscape">Landscape</string>
 
     <!-- Settings: Decode -->
     <string name="setting_h265">H.265 (HEVC)</string>


### PR DESCRIPTION
## Changes

### 1. Mirror Orientation Sync
- Switch Activity orientation based on video aspect ratio when mirroring
- Dynamically update AirPlay advertised resolution on orientation change
- Adjust startServer() resolution for portrait mode (swap width/height)
- Re-register mDNS service to notify sender of resolution changes
- Move videoAspect collection outside video lambda for orientation logic

### 2. Persistent FPS & Bandwidth Display
- Add StreamStats data class with FPS and bitrate formatting
- Sample stream stats every 60s in ViewModel when mirroring is active
- Show FPS/bandwidth label in OverviewContent and FullscreenVideo
- Add showStreamStats settings toggle (default on) in display section
- Add string resources for the new settings option