### PR TITLE
Fix Qualcomm HEVC black screen and reset decoder sessions

### DIFF
--- a/app/src/main/cpp/android_raop_callbacks.c
+++ b/app/src/main/cpp/android_raop_callbacks.c
@@ -63,7 +63,7 @@ void android_callbacks_init(android_callback_ctx_t *ctx, JNIEnv *env, jobject ca
     ctx->on_coverart = (*env)->GetMethodID(env, cls, "onCoverArt", "([B)V");
     ctx->on_progress = (*env)->GetMethodID(env, cls, "onProgress", "(JJJ)V");
     ctx->on_dacp_id = (*env)->GetMethodID(env, cls, "onDacpId", "(Ljava/lang/String;Ljava/lang/String;)V");
-    ctx->on_audio_only = (*env)->GetMethodID(env, cls, "onAudioOnly", "(Z)V");
+    ctx->on_mirror_running = (*env)->GetMethodID(env, cls, "onMirrorRunning", "(Z)V");
     ctx->on_video_play = (*env)->GetMethodID(env, cls, "onVideoPlay", "(Ljava/lang/String;F)V");
     ctx->on_video_scrub = (*env)->GetMethodID(env, cls, "onVideoScrub", "(F)V");
     ctx->on_video_rate = (*env)->GetMethodID(env, cls, "onVideoRate", "(F)V");
@@ -113,6 +113,11 @@ static void _video_process(void *cls, raop_ntp_t *ntp, video_decode_struct *data
     android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
     JNIEnv *env = _get_env(ctx);
     if (!env || !data->data || data->data_len <= 0) return;
+    /* raop_rtp_mirror marks undecryptable packets by setting byte 0 (start code) to 1 */
+    if (data->data[0]) {
+        LOGE("video packet decryption failed, dropping %d bytes", data->data_len);
+        return;
+    }
 
     jbyteArray arr = (*env)->NewByteArray(env, data->data_len);
     (*env)->SetByteArrayRegion(env, arr, 0, data->data_len, (jbyte *)data->data);
@@ -274,8 +279,7 @@ static void _mirror_video_running(void *cls, bool running) {
     JNIEnv *env = _get_env(ctx);
     if (!env) return;
     LOGI("mirror running: %d", running);
-    /* audio-only = mirror NOT running */
-    (*env)->CallVoidMethod(env, ctx->callback_obj, ctx->on_audio_only, (jboolean)!running);
+    (*env)->CallVoidMethod(env, ctx->callback_obj, ctx->on_mirror_running, (jboolean)running);
 }
 static void _register_client(void *cls, const char *device_id, const char *pk_str, const char *name) {
     android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;

--- a/app/src/main/cpp/android_raop_callbacks.h
+++ b/app/src/main/cpp/android_raop_callbacks.h
@@ -28,7 +28,7 @@ typedef struct {
     jmethodID on_coverart;
     jmethodID on_progress;
     jmethodID on_dacp_id;
-    jmethodID on_audio_only;
+    jmethodID on_mirror_running;
     jmethodID on_video_play;
     jmethodID on_video_scrub;
     jmethodID on_video_rate;

--- a/app/src/main/cpp/patches/UxPlay/0007-reset-mirror-decrypt-state-on-rekey.patch
+++ b/app/src/main/cpp/patches/UxPlay/0007-reset-mirror-decrypt-state-on-rekey.patch
@@ -1,0 +1,14 @@
+diff --git a/lib/mirror_buffer.c b/lib/mirror_buffer.c
+index d6d5667..beaaf03 100644
+--- a/lib/mirror_buffer.c
++++ b/lib/mirror_buffer.c
+@@ -64,7 +64,9 @@ mirror_buffer_init_aes(mirror_buffer_t *mirror_buffer, const uint64_t *streamCon
+     sha_destroy(ctx);
+ 
+     // Need to be initialized externally
++    aes_ctr_destroy(mirror_buffer->aes_ctx);
+     mirror_buffer->aes_ctx = aes_ctr_init(aeskey_video, aesiv_video);
++    mirror_buffer->nextDecryptCount = 0;
+ }
+ 
+ mirror_buffer_t *

--- a/app/src/main/kotlin/io/github/jqssun/airplay/Prefs.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/Prefs.kt
@@ -16,7 +16,8 @@ object Prefs {
     const val ENFORCE_SDR = "enforce_sdr"; const val DEF_ENFORCE_SDR = true
     val KEY_ALLOW_FRAME_DROP: String = MediaFormat.KEY_ALLOW_FRAME_DROP; const val DEF_KEY_ALLOW_FRAME_DROP = true
     val KEY_PRIORITY: String = MediaFormat.KEY_PRIORITY; const val DEF_KEY_PRIORITY = true
-    val KEY_OPERATING_RATE: String = MediaFormat.KEY_OPERATING_RATE; const val DEF_KEY_OPERATING_RATE = true
+    // unsafe operating rate disabled for c2.qti.hevc.decoder on sunfish
+    val KEY_OPERATING_RATE: String = MediaFormat.KEY_OPERATING_RATE; const val DEF_KEY_OPERATING_RATE = false
     const val LOW_LATENCY = "low_latency"; const val DEF_LOW_LATENCY = false
     const val SCHEDULED_OUTPUT_BUFFER_RELEASE = "scheduled_output_buffer_release"; const val DEF_SCHEDULED_OUTPUT_BUFFER_RELEASE = false
     const val AUDIO_AUTO_BUFFER = "audio_auto_buffer"; const val DEF_AUDIO_AUTO_BUFFER = true

--- a/app/src/main/kotlin/io/github/jqssun/airplay/bridge/RaopCallbackHandler.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/bridge/RaopCallbackHandler.kt
@@ -15,7 +15,7 @@ interface RaopCallbackHandler {
     fun onCoverArt(data: ByteArray)
     fun onProgress(start: Long, curr: Long, end: Long)
     fun onDacpId(dacpId: String, activeRemote: String)
-    fun onAudioOnly(audioOnly: Boolean)
+    fun onMirrorRunning(running: Boolean)
     // video (hls), distinct from mirroring and raop audio
     fun onVideoPlay(location: String, startPositionSeconds: Float)
     fun onVideoScrub(positionSeconds: Float)

--- a/app/src/main/kotlin/io/github/jqssun/airplay/renderer/VideoRenderer.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/renderer/VideoRenderer.kt
@@ -62,6 +62,17 @@ class VideoRenderer {
         pipeline.setDisplaySurface(null)
     }
 
+    // codec per mirror session; pipeline persists across sessions
+    fun startSession() = synchronized(lock) { _resetStats() }
+
+    fun stopSession() = synchronized(lock) { stopCodec() }
+
+    private fun _resetStats() {
+        fps = 0; bitrateBps = 0; frameCount = 0; codecName = ""
+        droppedFrames = 0; framePacingJitterUs = 0
+        _framesThisSec = 0; _bytesThisSec = 0
+    }
+
     private fun _updateStats(size: Int) {
         val now = System.currentTimeMillis()
         if (now - _lastStatReset >= 1000) {
@@ -88,9 +99,8 @@ class VideoRenderer {
     }
 
     fun feedFrame(data: ByteArray, ntpTimeNs: Long, isH265: Boolean) {
-        _updateStats(data.size)
-
         synchronized(lock) {
+            _updateStats(data.size)
             if (videoWidth == 0 || videoHeight == 0) return
 
             if (codec == null || isH265 != currentH265) {
@@ -247,10 +257,7 @@ class VideoRenderer {
     fun release() = synchronized(lock) {
         stopCodec()
         pipeline.release()
-        fps = 0; bitrateBps = 0; frameCount = 0; codecName = ""
-        droppedFrames = 0; framePacingJitterUs = 0
-        _framesThisSec = 0; _bytesThisSec = 0
-        _frameIntervalIdx = 0; _frameIntervalCount = 0; _lastOutputFrameNs = 0L
+        _resetStats()
     }
 
     private fun _recordOutputFrameTime() {

--- a/app/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
+++ b/app/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
@@ -132,7 +132,7 @@ class AirPlayService : LifecycleService(), RaopCallbackHandler, LogListener {
             !_videoPollSuppressed &&
             SystemClock.elapsedRealtime() - _lastVideoPollAt < VIDEO_POLL_PENDING_TIMEOUT_MS
 
-    // set once mirroring reports a real size; connectionCount can't tell session kinds apart
+    // set once mirroring reports a real size; stops with session
     private val _mirroringActive = MutableStateFlow(false)
     val mirroringActive = _mirroringActive.asStateFlow()
 
@@ -177,7 +177,6 @@ class AirPlayService : LifecycleService(), RaopCallbackHandler, LogListener {
     private val _volSyncTimeout = Runnable { _volSyncEnd() }
 
     var logCallback: ((String) -> Unit)? = null
-    var modeCallback: ((Boolean) -> Unit)? = null
 
     @Volatile private var _lastPin: String? = null
     var pinCallback: ((String?) -> Unit)? = null
@@ -641,7 +640,7 @@ class AirPlayService : LifecycleService(), RaopCallbackHandler, LogListener {
         if (!usingScreen) _setPlaying(true)
         if (!usingScreen && !_audioOnly.value) {
             // pure music streaming (not screen mirroring audio)
-            onAudioOnly(true)
+            _setAudioOnly(true)
         }
         log("Audio format: ct=$ct spf=$spf screen=$usingScreen")
     }
@@ -733,7 +732,6 @@ class AirPlayService : LifecycleService(), RaopCallbackHandler, LogListener {
             // last client gone: release audio output devices to save power
             audioRenderer.stop()
             _audioOnly.value = false
-            _mirroringActive.value = false
             _lastVideoPollAt = 0
             _videoPollSuppressed = false
             _coverArtBytes = null
@@ -810,13 +808,20 @@ class AirPlayService : LifecycleService(), RaopCallbackHandler, LogListener {
         log("DACP: $dacpId")
     }
 
-    override fun onAudioOnly(audioOnly: Boolean) {
+    override fun onMirrorRunning(running: Boolean) {
+        if (running) videoRenderer.startSession() else {
+            videoRenderer.stopSession()
+            _mirroringActive.value = false
+        }
+        _setAudioOnly(!running)
+    }
+
+    private fun _setAudioOnly(audioOnly: Boolean) {
         val prev = _audioOnly.value
         _audioOnly.value = audioOnly
         _refreshDacpPlayer()
         if (audioOnly && !prev) {
             mediaSession?.isActive = true
-            modeCallback?.invoke(true)
             log("Audio mode")
         } else if (!audioOnly && prev) {
             mediaSession?.isActive = false
@@ -825,7 +830,6 @@ class AirPlayService : LifecycleService(), RaopCallbackHandler, LogListener {
             _positionMs.value = 0
             _durationMs.value = 0
             _updateMediaNotification()
-            modeCallback?.invoke(false)
             log("Mirror mode")
         }
     }


### PR DESCRIPTION
## Summary

- disable the maximum-throughput `operating-rate` hint by default
- reset `MediaCodec` at the end of each mirroring session, connection reset, or final client disconnect
- keep the persistent GL/display pipeline alive while resetting only decoder-session state

## Root cause

On a Pixel 4a running Android 13, the default `operating-rate=32767` config wedges `c2.qti.hevc.decoder` before its first output frame. The decoder starts successfully, then stops returning input buffers and every subsequent frame is dropped. The stalled codec was also retained across mirroring sessions, so later connections remained black until the whole service restarted.

## Validation

Tested on Pixel 4a (`sunfish`, Android 13) with a 994x2160 H.265 AirPlay mirroring stream:

- before: decoder input queue stalls immediately and the dropped-frame count grows continuously
- after disabling the operating-rate hint: video renders normally with no input-queue drops
- ending mirroring logs `Resetting video decoder session`, and the next session creates a fresh codec
- Debug APK built successfully in GitHub Actions

Build run: https://github.com/scavin/android-airplay-server/actions/runs/31356665266
